### PR TITLE
Added support for off-diagonal S elements

### DIFF
--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -15,7 +15,7 @@ abstract type AbstractLQDynData{T,V} end
 A struct to represent the features of the optimization problem 
 
 ```math
-    minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
+    minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
     subject to  s_{i+1} = A s_i + B u_i  for i=0, 1, ..., N-1
                 gl \\le E s_i + F u_i \\le gu for i = 0, 1, ..., N-1
                 sl \\le s \\le su
@@ -30,7 +30,8 @@ Attributes include:
 - `Q` : objective function matrix for system states from 1:(N-1)
 - `R` : objective function matrix for system inputs from 1:(N-1)
 - `N` : number of time steps
-- `Qf`: objective function matrix for system state at time N; defaults to Q
+- `Qf`: objective function matrix for system state at time N
+- `S` : objective function matrix for system states and inputs
 - `ns`: number of state variables
 - `nu`: number of input varaibles
 - `E` : constraint matrix for state variables
@@ -71,7 +72,7 @@ end
     LQDynamicData(s0, A, B, Q, R, N; ...) -> LQDynamicData{T, V, M}
 A constructor for building an object of type `LQDynamicData` for the optimization problem 
 ```math
-    minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
+    minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
     subject to  s_{i+1} = A s_i + B u_i  for i=0, 1, ..., N-1
                 gl \\le E s_i + F u_i \\le gu for i = 0, 1, ..., N-1
                 sl \\le s \\le su
@@ -90,6 +91,7 @@ The following attributes of the `LQDynamicData` type are detected automatically 
 - `nu`: number of input varaibles
 The following keyward arguments are also accepted
 - `Qf = Q`: objective function matrix for system state at time N; dimensions must be ns x ns
+- `S = zeros(size(Q, 1), size(R, 1))`: objective function matrix for system state and inputs
 - `E  = zeros(0, ns)` : constraint matrix for state variables
 - `F  = zeros(0, nu)` : constraint matrix for input variables
 - `sl = fill(-Inf, ns)`: vector of lower bounds on state variables
@@ -199,7 +201,7 @@ end
 A constructor for building a `LQDynamicModel <: QuadraticModels.AbstractQuadraticModel` from `LQDynamicData`
 Input data is for the problem of the form 
 ```math
-    minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
+    minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
     subject to  s_{i+1} = A s_i + B u_i  for i=0, 1, ..., N-1
                 gl \\le E s_i + F u_i \\le gu for i = 0, 1, ..., N-1            
                 sl \\le s \\le su

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -165,7 +165,7 @@ function LQDynamicData(
         error("Dimensions of gu do not match E and F")
     end
 
-    if size(S, 1) != size(Q, 1) || size(S,2) != size(R,1)
+    if size(S, 1) != size(Q, 1) || size(S, 2) != size(R, 1)
         error("Dimensions of S do not match dimensions of Q and R")
     end
 
@@ -250,7 +250,7 @@ function LQDynamicModel(
     R::M,
     N;
     Qf::M = Q, 
-    S::M  = zeros(size(Q, 1), size(Q, 2)),
+    S::M  = zeros(size(Q, 1), size(R, 1)),
     E::M  = zeros(0, length(s0)),
     F::M  = zeros(0, size(R, 1)),
     sl::V = (similar(s0) .= -Inf),

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -8,9 +8,9 @@ import SparseArrays: SparseMatrixCSC
 
 export get_QM, LQDynamicData, LQDynamicModel
 
-abstract type AbstractLQDynData{T,S} end
+abstract type AbstractLQDynData{T,V} end
 """
-    LQDynamicData{T,S,M} <: AbstractLQDynData{T,S}
+    LQDynamicData{T,V,M} <: AbstractLQDynData{T,V}
 
 A struct to represent the features of the optimization problem 
 
@@ -44,8 +44,8 @@ Attributes include:
 
 see also `LQDynamicData(s0, A, B, Q, R, N; ...)`
 """
-struct LQDynamicData{T,S,M} <: AbstractLQDynData{T,S}
-    s0::S
+struct LQDynamicData{T,V,M} <: AbstractLQDynData{T,V}
+    s0::V
     A::M
     B::M
     Q::M
@@ -53,21 +53,22 @@ struct LQDynamicData{T,S,M} <: AbstractLQDynData{T,S}
     N
 
     Qf::M
+    S::M
     ns::Int
     nu::Int
     E::M
     F::M
 
-    sl::S
-    su::S
-    ul::S
-    uu::S
-    gl::S
-    gu::S
+    sl::V
+    su::V
+    ul::V
+    uu::V
+    gl::V
+    gu::V
 end
 
 """
-    LQDynamicData(s0, A, B, Q, R, N; ...) -> LQDynamicData{T, S, M}
+    LQDynamicData(s0, A, B, Q, R, N; ...) -> LQDynamicData{T, V, M}
 A constructor for building an object of type `LQDynamicData` for the optimization problem 
 ```math
     minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
@@ -99,7 +100,7 @@ The following keyward arguments are also accepted
 - `gu = fill(Inf, size(E, 1))`  : vector of upper bounds on constraints
 """
 function LQDynamicData(
-    s0::S,
+    s0::V,
     A::M,
     B::M,
     Q::M,
@@ -107,30 +108,31 @@ function LQDynamicData(
     N;
 
     Qf::M = Q, 
+    S::M  = zeros(size(Q, 1), size(R, 1)),
     E::M  = zeros(0, length(s0)),
     F::M  = zeros(0, size(R, 1)),
 
-    sl::S = (similar(s0) .= -Inf),
-    su::S = (similar(s0) .=  Inf),
-    ul::S = (similar(s0,size(R,1)) .= -Inf),
-    uu::S = (similar(s0,size(R,1)) .=  Inf),
-    gl::S = fill(-Inf, size(E, 1)),
-    gu::S = fill(Inf, size(F, 1))
-    ) where {T,S <: AbstractVector{T},M <: AbstractMatrix{T}}
+    sl::V = (similar(s0) .= -Inf),
+    su::V = (similar(s0) .=  Inf),
+    ul::V = (similar(s0, size(R,1)) .= -Inf),
+    uu::V = (similar(s0, size(R,1)) .=  Inf),
+    gl::V = fill(-Inf, size(E, 1)),
+    gu::V = fill(Inf, size(F, 1))
+    ) where {T,V <: AbstractVector{T}, M <: AbstractMatrix{T}}
 
-    if size(Q,1) != size(Q,2) 
+    if size(Q, 1) != size(Q, 2) 
         error("Q matrix is not square")
     end
-    if size(R,1) != size(R,1)
+    if size(R, 1) != size(R, 1)
         error("R matrix is not square")
     end
-    if size(A,2) != length(s0)
+    if size(A, 2) != length(s0)
         error("Number of columns of A are not equal to the number of states")
     end
-    if size(B,2) != size(R,1)
+    if size(B, 2) != size(R, 1)
         error("Number of columns of B are not equal to the number of inputs")
     end
-    if length(s0) != size(Q,1)
+    if length(s0) != size(Q, 1)
         error("size of Q is not consistent with length of x0")
     end
 
@@ -144,23 +146,27 @@ function LQDynamicData(
         error("x0 is not within the given upper and lower bounds")
     end
 
-    if size(E,1) != size(F,1)
+    if size(E, 1) != size(F, 1)
         error("E and F have different numbers of rows")
     end
     if !(gl <= gu)
         error("lower bound(s) on Es + Fu is > upper bound(s)")
     end
-    if size(E,2) != size(Q, 1)
+    if size(E, 2) != size(Q, 1)
         error("Dimensions of E are not the same as number of states")
     end
-    if size(F,2) != size(R,1) 
+    if size(F, 2) != size(R, 1) 
         error("Dimensions of F are not the same as the number of inputs")
     end
-    if length(gl) != size(E,1)
+    if length(gl) != size(E, 1)
         error("Dimensions of gl do not match E and F")
     end
-    if length(gu) != size(E,1)
+    if length(gu) != size(E, 1)
         error("Dimensions of gu do not match E and F")
+    end
+
+    if size(S, 1) != size(Q, 1) || size(S,2) != size(R,1)
+        error("Dimensions of S do not match dimensions of Q and R")
     end
 
 
@@ -168,22 +174,22 @@ function LQDynamicData(
     ns= size(Q,1)
     nu= size(R,1)
 
-    LQDynamicData{T,S,M}(
+    LQDynamicData{T,V,M}(
         s0, A, B, Q, R, N,
-        Qf, ns, nu, E, F,
+        Qf, S, ns, nu, E, F,
         sl, su, ul, uu, gl, gu
     )
 end
 
 
 
-abstract type AbstractDynamicModel{T,S} <: QuadraticModels.AbstractQuadraticModel{T, S} end
+abstract type AbstractDynamicModel{T,V} <: QuadraticModels.AbstractQuadraticModel{T, V} end
 
-mutable struct LQDynamicModel{T, S, M1, M2, M3} <:  AbstractDynamicModel{T,S} 
-  meta::NLPModels.NLPModelMeta{T, S}
+mutable struct LQDynamicModel{T, V, M1, M2, M3} <:  AbstractDynamicModel{T,V} 
+  meta::NLPModels.NLPModelMeta{T, V}
   counters::NLPModels.Counters
-  data::QuadraticModels.QPData{T, S, M1, M2}
-  dynamic_data::LQDynamicData{T,S,M3}
+  data::QuadraticModels.QPData{T, V, M1, M2}
+  dynamic_data::LQDynamicData{T, V, M3}
   condense::Bool
 end
 
@@ -224,7 +230,7 @@ If `condense=true`, data is converted to the form
 
 Resulting `H`, `J`, `h`, and `h0` matrices are stored within `QuadraticModels.QPData` as `H`, `A`, `c`, and `c0` attributes respectively
 """
-function LQDynamicModel(dnlp::LQDynamicData{T,S,M}; condense = false) where {T,S <: AbstractVector{T} ,M  <: AbstractMatrix{T}}
+function LQDynamicModel(dnlp::LQDynamicData{T,V,M}; condense = false) where {T, V <: AbstractVector{T}, M  <: AbstractMatrix{T}}
 
     if condense==false
         _build_sparse_lq_dynamic_model(dnlp)
@@ -237,31 +243,32 @@ end
 
 
 function LQDynamicModel(
-    s0::S,
+    s0::V,
     A::M,
     B::M,
     Q::M,
     R::M,
     N;
     Qf::M = Q, 
+    S::M  = zeros(size(Q, 1), size(Q, 2)),
     E::M  = zeros(0, length(s0)),
     F::M  = zeros(0, size(R, 1)),
-    sl::S = (similar(s0) .= -Inf),
-    su::S = (similar(s0) .=  Inf),
-    ul::S = (similar(s0,size(R, 1)) .= -Inf),
-    uu::S = (similar(s0,size(R, 1)) .=  Inf),
-    gl::S = fill(-Inf, size(E, 1)),
-    gu::S = fill(Inf, size(F, 1)),
+    sl::V = (similar(s0) .= -Inf),
+    su::V = (similar(s0) .=  Inf),
+    ul::V = (similar(s0,size(R, 1)) .= -Inf),
+    uu::V = (similar(s0,size(R, 1)) .=  Inf),
+    gl::V = fill(-Inf, size(E, 1)),
+    gu::V = fill(Inf, size(F, 1)),
     condense=false
-    ) where {T,S <: AbstractVector{T},M <: AbstractMatrix{T}}
+    ) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}}
 
-    dnlp = LQDynamicData(s0, A, B, Q, R, N; Qf = Qf, E = E, F = F, sl = sl, su = su, ul = ul, uu = uu, gl = gl, gu = gu)
+    dnlp = LQDynamicData(s0, A, B, Q, R, N; Qf = Qf, S = S, E = E, F = F, sl = sl, su = su, ul = ul, uu = uu, gl = gl, gu = gu)
     
     LQDynamicModel(dnlp; condense=condense)
 
 end
 
-function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T,S,M}) where {T,S <: AbstractVector{T} ,M  <: AbstractMatrix{T}}
+function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T,V,M}) where {T, V <: AbstractVector{T}, M  <: AbstractMatrix{T}}
     s0 = dnlp.s0
     A  = dnlp.A
     B  = dnlp.B
@@ -270,6 +277,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T,S,M}) where {T,S <
     N  = dnlp.N
 
     Qf = dnlp.Qf
+    S  = dnlp.S
     ns = dnlp.ns
     nu = dnlp.nu
     E  = dnlp.E
@@ -284,7 +292,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T,S,M}) where {T,S <
 
 
 
-    H   = _build_H(Q, R, N; Qf = Qf)
+    H   = _build_H(Q, R, N; Qf = Qf, S = S)
     J1  = _build_sparse_J1(A, B, N)
     J2  = _build_sparse_J2(E, F, N)
     J   = vcat(J1, J2)
@@ -349,7 +357,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T,S,M}) where {T,S <
 
 end
 
-function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,S,M}) where {T,S <: AbstractVector{T} ,M  <: AbstractMatrix{T}}
+function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M}) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}}
     s0 = dnlp.s0
     A  = dnlp.A
     B  = dnlp.B
@@ -358,6 +366,7 @@ function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,S,M}) where {T,
     N  = dnlp.N
 
     Qf = dnlp.Qf
+    S  = dnlp.S
     ns = dnlp.ns
     nu = dnlp.nu
     E  = dnlp.E
@@ -371,7 +380,7 @@ function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,S,M}) where {T,
     gu = dnlp.gu
 
     
-    condensed_blocks = _build_condensed_blocks(s0, Q, R, A, B, N; Qf = Qf)
+    condensed_blocks = _build_condensed_blocks(s0, Q, R, A, B, N; Qf = Qf, S = S)
 
     block_A = condensed_blocks.block_A
     block_B = condensed_blocks.block_B
@@ -493,7 +502,8 @@ end
 
 function _build_condensed_blocks(
     s0, Q, R, A, B, N;
-    Qf = Q)
+    Qf = Q, 
+    S = zeros(size(Q, 1), size(R, 1)))
   
     ns = size(Q, 1)
     nu = size(R, 1)
@@ -549,6 +559,7 @@ function _build_condensed_blocks(
         end
     end
   
+
     LinearAlgebra.mul!(A_k, A, A_klast)
 
     block_A[(ns * N + 1):ns * (N + 1), :] .= A_k
@@ -576,6 +587,29 @@ function _build_condensed_blocks(
   
     c0 = h0[1,1] / 2
   
+    if S != zeros(size(Q, 1), size(R, 1))
+        block_S = zeros(ns * (N + 1), nu * N)
+
+        for i in 1:N
+            row_range = (1 + ns * (i - 1)):(ns * i)
+            col_range = (1 + nu * (i - 1)):(nu * i)
+
+            block_S[row_range, col_range] = S
+        end        
+
+        BTS      = zeros(nu * N, nu * N)
+        STB      = zeros(nu * N, nu * N)
+        s0T_AT_S = zeros(1, nu * N)
+
+        LinearAlgebra.mul!(BTS, transpose(block_B), block_S)
+        LinearAlgebra.mul!(STB, transpose(block_S), block_B)
+
+        LinearAlgebra.axpy!(1, BTS, BQB)
+        LinearAlgebra.axpy!(1, STB, BQB)
+
+        LinearAlgebra.mul!(s0T_AT_S, s0TAT, block_S)
+        LinearAlgebra.axpy!(1, s0T_AT_S, h)
+    end
   
     return (H = BQB, c = vec(h), c0 = c0, block_A = block_A, block_B = block_B, block_Q = block_Q, block_R = block_R)
 end
@@ -660,19 +694,19 @@ function fill_coord!(S::SparseMatrixCSC, vals, obj_weight)
 end
 
 function NLPModels.hess_structure!(
-  qp::LQDynamicModel{T, S, M1, M2, M3},
+  qp::LQDynamicModel{T, V, M1, M2, M3},
   rows::AbstractVector{<:Integer},
   cols::AbstractVector{<:Integer},
-) where {T, S, M1 <: SparseMatrixCSC, M2 <: SparseMatrixCSC, M3<: AbstractMatrix}
+) where {T, V, M1 <: SparseMatrixCSC, M2 <: SparseMatrixCSC, M3<: AbstractMatrix}
   fill_structure!(qp.data.H, rows, cols)
   return rows, cols
 end
 
 function NLPModels.hess_structure!(
-  qp::LQDynamicModel{T, S, M1, M2, M3},
+  qp::LQDynamicModel{T, V, M1, M2, M3},
   rows::AbstractVector{<:Integer},
   cols::AbstractVector{<:Integer},
-) where {T, S, M1 <: Matrix, M2<: Matrix, M3<: Matrix}
+) where {T, V, M1 <: Matrix, M2<: Matrix, M3<: Matrix}
   count = 1
   for j = 1:(qp.meta.nvar)
     for i = j:(qp.meta.nvar)
@@ -686,22 +720,22 @@ end
 
 
 function NLPModels.hess_coord!(
-  qp::LQDynamicModel{T, S, M1, M2, M3},
+  qp::LQDynamicModel{T, V, M1, M2, M3},
   x::AbstractVector{T},
   vals::AbstractVector{T};
   obj_weight::Real = one(eltype(x)),
-) where {T, S, M1 <: SparseMatrixCSC, M2 <: SparseMatrixCSC, M3 <: Matrix}
+) where {T, V, M1 <: SparseMatrixCSC, M2 <: SparseMatrixCSC, M3 <: Matrix}
   NLPModels.increment!(qp, :neval_hess)
   fill_coord!(qp.data.H, vals, obj_weight)
   return vals
 end
 
 function NLPModels.hess_coord!(
-  qp::LQDynamicModel{T, S, M1, M2, M3},
+  qp::LQDynamicModel{T, V, M1, M2, M3},
   x::AbstractVector{T},
   vals::AbstractVector{T};
   obj_weight::Real = one(eltype(x)),
-) where {T, S, M1 <: Matrix, M2 <: Matrix, M3 <: Matrix}
+) where {T, V, M1 <: Matrix, M2 <: Matrix, M3 <: Matrix}
   NLPModels.increment!(qp, :neval_hess)
   count = 1
   for j = 1:(qp.meta.nvar)
@@ -722,19 +756,19 @@ NLPModels.hess_coord!(
 ) = NLPModels.hess_coord!(qp, x, vals, obj_weight = obj_weight)
 
 function NLPModels.jac_structure!(
-  qp::LQDynamicModel{T, S, M1, M2, M3},
+  qp::LQDynamicModel{T, V, M1, M2, M3},
   rows::AbstractVector{<:Integer},
   cols::AbstractVector{<:Integer},
-) where {T, S, M1 <: SparseMatrixCSC, M2 <: SparseMatrixCSC, M3<: AbstractMatrix}
+) where {T, V, M1 <: SparseMatrixCSC, M2 <: SparseMatrixCSC, M3<: AbstractMatrix}
   fill_structure!(qp.data.A, rows, cols)
   return rows, cols
 end
 
 function NLPModels.jac_structure!(
-  qp::LQDynamicModel{T, S, M1, M2, M3},
+  qp::LQDynamicModel{T, V, M1, M2, M3},
   rows::AbstractVector{<:Integer},
   cols::AbstractVector{<:Integer},
-) where {T, S, M1<: Matrix, M2 <: Matrix, M3 <: Matrix}
+) where {T, V, M1<: Matrix, M2 <: Matrix, M3 <: Matrix}
   count = 1
   for j = 1:(qp.meta.nvar)
     for i = 1:(qp.meta.ncon)
@@ -747,20 +781,20 @@ function NLPModels.jac_structure!(
 end
 
 function NLPModels.jac_coord!(
-  qp::LQDynamicModel{T, S, M1, M2, M3},
+  qp::LQDynamicModel{T, V, M1, M2, M3},
   x::AbstractVector,
   vals::AbstractVector,
-) where {T, S, M1 <: SparseMatrixCSC, M2 <: SparseMatrixCSC, M3 <: AbstractMatrix}
+) where {T, V, M1 <: SparseMatrixCSC, M2 <: SparseMatrixCSC, M3 <: AbstractMatrix}
   NLPModels.increment!(qp, :neval_jac)
   fill_coord!(qp.data.A, vals, one(T))
   return vals
 end
 
 function NLPModels.jac_coord!(
-  qp::LQDynamicModel{T, S, M1, M2, M3},
+  qp::LQDynamicModel{T, V, M1, M2, M3},
   x::AbstractVector,
   vals::AbstractVector,
-) where {T, S, M1 <: Matrix, M2 <: Matrix, M3 <: Matrix}
+) where {T, V, M1 <: Matrix, M2 <: Matrix, M3 <: Matrix}
   NLPModels.increment!(qp, :neval_jac)
   count = 1
   for j = 1:(qp.meta.nvar)
@@ -796,7 +830,8 @@ If `Qf` is not given, then `Qf` defaults to `Q`
 """
 function _build_H(
     Q::M, R::M, N;
-    Qf::M = Q) where M <: AbstractMatrix
+    Qf::M = Q,
+    S::M = zeros(size(Q, 1), size(R, 1))) where M <: AbstractMatrix
     ns = size(Q, 1)
     nu = size(R, 1)
 
@@ -807,6 +842,9 @@ function _build_H(
         range_R = (ns * (N + 1) + 1 + (i - 1) * nu):(ns * (N + 1) + i * nu)
         H[range_Q, range_Q] = Q
         H[range_R, range_R] = R
+
+        H[range_Q, range_R] = S
+        H[range_R, range_Q] = transpose(S)
     end
 
     H[(N * ns + 1):( N * ns + ns), (N * ns + 1):(N * ns + ns)] = Qf
@@ -881,5 +919,3 @@ function _build_sparse_J2(E, F, N)
 end
 
 end # module
-
- 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,10 +23,24 @@ su = sl .+ 4
 uu = ul .+ 10
 s0 = sl .+ 2
 
+su_with_inf = copy(su)
+sl_with_inf = copy(sl)
 
-# Add Qf matrix
+su_with_inf[1] = Inf
+sl_with_inf[1] = -Inf
+
+
 Qf_rand = Random.rand(ns,ns)
 Qf = Qf_rand * transpose(Qf_rand) + I
+
+E  = rand(3, ns)
+F  = rand(3, nu)
+gl = fill(-5.0, 3)
+gu = fill(15.0, 3)
+
+S = rand(ns, nu)
+
+
 
 # Test with no bounds
 model       = build_QP_JuMP_model(Q,R,A,B, N;s0=s0)
@@ -155,11 +169,6 @@ solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
 
 
 # Test with E and F matrix bounds
-E  = rand(3, ns)
-F  = rand(3, nu)
-gl = fill(-5.0, 3)
-gu = fill(15.0, 3)
-
 model       = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
 dnlp        = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
 lq_sparse   = LQDynamicModel(dnlp; condense=false)
@@ -184,16 +193,13 @@ solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
 
 
 # Test edge case where one state is unbounded, other(s) is bounded
-su[1] = Inf
-sl[1] = -Inf
-
-model       = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
-dnlp        = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
+model       = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu)
+dnlp        = LQDynamicData(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu)
 lq_sparse   = LQDynamicModel(dnlp; condense=false)
 lq_condense = LQDynamicModel(dnlp; condense=true)
 
-lq_sparse_from_data   = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, condense=false)
-lq_condense_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, condense=true)
+lq_sparse_from_data   = LQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu, condense=false)
+lq_condense_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu, condense=true)
 
 optimize!(model)
 solution_ref_sparse             = madnlp(lq_sparse, max_iter=100) 
@@ -210,3 +216,29 @@ solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
 @test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-6
 
 @test size(lq_condense.data.A, 1) == size(E, 1) * 3 + sum(su .!= Inf .|| sl .!= -Inf) * N
+
+
+# Test S matrix case
+model       = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
+dnlp        = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
+lq_sparse   = LQDynamicModel(dnlp; condense=false)
+lq_condense = LQDynamicModel(dnlp; condense=true)
+
+lq_sparse_from_data   = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S, condense=false)
+lq_condense_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S, condense=true)
+
+optimize!(model)
+
+optimize!(model)
+solution_ref_sparse             = madnlp(lq_sparse, max_iter=100) 
+solution_ref_condense           = madnlp(lq_condense, max_iter=100)
+solution_ref_sparse_from_data   = madnlp(lq_sparse_from_data, max_iter=100)
+solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
+
+@test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_condense.objective atol = 1e-5
+@test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_condense_from_data.objective atol = 1e-5
+
+@test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-6
+@test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -215,7 +215,7 @@ solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
 @test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-6
 @test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-6
 
-@test size(lq_condense.data.A, 1) == size(E, 1) * 3 + sum(su .!= Inf .|| sl .!= -Inf) * N
+@test size(lq_condense.data.A, 1) == size(E, 1) * 3 + sum(su_with_inf .!= Inf .|| sl_with_inf .!= -Inf) * N
 
 
 # Test S matrix case

--- a/test/sparse_lq_test.jl
+++ b/test/sparse_lq_test.jl
@@ -28,7 +28,8 @@ function build_QP_JuMP_model(
         E  = [],
         F  = [],
         gl = [],
-        gu = []
+        gu = [],
+        S  = []
         )
 
     if size(Qf,1) == 0
@@ -47,8 +48,8 @@ function build_QP_JuMP_model(
     model = Model(MadNLP.Optimizer) # define model
 
 
-        @variable(model, s[NS, 0:N]) # define states 
-        @variable(model, u[NU, 0:(N-1)]) # define inputs
+    @variable(model, s[NS, 0:N]) # define states 
+    @variable(model, u[NU, 0:(N-1)]) # define inputs
 
 
 
@@ -110,7 +111,9 @@ function build_QP_JuMP_model(
     # Give objective function as xT Q x + uT R u where x is summed over T and u is summed over T-1
     @objective(model,Min,  sum( 1/2 * Q[s1, s2]*s[s1,t]*s[s2,t] for s1 in NS, s2 in NS, t in 0:(N-1)) + 
             sum( 1/2 * R[u1,u2] * u[u1, t] * u[u2,t] for t in 0:(N-1) , u1 in NU, u2 in NU) + 
-            sum( 1/2 * Qf[s1,s2] * s[s1,N] * s[s2, N]  for s1 in NS, s2 in NS))
+            sum( 1/2 * Qf[s1,s2] * s[s1,N] * s[s2, N]  for s1 in NS, s2 in NS) +
+            sum( S[s1, u1] * s[s1, t] * u[u1, t] for s1 in NS, u1 in NU, t in NN)
+            )
 
     return model
 end

--- a/test/sparse_lq_test.jl
+++ b/test/sparse_lq_test.jl
@@ -29,7 +29,7 @@ function build_QP_JuMP_model(
         F  = [],
         gl = [],
         gu = [],
-        S  = []
+        S  = zeros(size(Q, 1), size(R, 1))
         )
 
     if size(Qf,1) == 0
@@ -112,7 +112,7 @@ function build_QP_JuMP_model(
     @objective(model,Min,  sum( 1/2 * Q[s1, s2]*s[s1,t]*s[s2,t] for s1 in NS, s2 in NS, t in 0:(N-1)) + 
             sum( 1/2 * R[u1,u2] * u[u1, t] * u[u2,t] for t in 0:(N-1) , u1 in NU, u2 in NU) + 
             sum( 1/2 * Qf[s1,s2] * s[s1,N] * s[s2, N]  for s1 in NS, s2 in NS) +
-            sum( S[s1, u1] * s[s1, t] * u[u1, t] for s1 in NS, u1 in NU, t in NN)
+            sum( S[s1, u1] * s[s1, t] * u[u1, t] for s1 in NS, u1 in NU, t in 0:(N-1))
             )
 
     return model


### PR DESCRIPTION
Added support to `LQDynamicData` and `LQDynamicModel` to handle non diagonal `S` matrix in the objective function. `LQDynamicData` now has an attribute for `S`, and `LQDynamicModel` now incorporates `S` into the construction of `H` for both sparse and condensed forms. Also updated `sparse_lq_test.jl` so that the JuMP formulation includes the `S` matrix and added a new test for the addition of the `S` matrix. Also changed type variable in source code so that it uses `V` in place of `S` (e.g., `LQDynamicData{T, S, M}` is now `LQDynamicData{T, V, M}`. 
