### PR TITLE
Added support for `K` state elimination

### DIFF
--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -530,7 +530,7 @@ function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where 
     c  = H_blocks.c
     c0 = H_blocks.c0
 
-    G_blocks = _build_condensed_G_blocks(block_A, block_B, block_E, block_F, block_K, block_gl, block_gu, s0, N, K)
+    G_blocks = _build_condensed_G_blocks(block_A, block_B, block_E, block_F, block_K, block_gl, block_gu, s0, N)
 
     J1   = G_blocks.J
     lcon = G_blocks.lcon
@@ -656,7 +656,7 @@ function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where 
     c  = H_blocks.c
     c0 = H_blocks.c0
 
-    G_blocks = _build_condensed_G_blocks(block_A, block_B, block_E, block_F, block_K, block_gl, block_gu, s0, N, K)
+    G_blocks = _build_condensed_G_blocks(block_A, block_B, block_E, block_F, block_K, block_gl, block_gu, s0, N)
 
     J1   = G_blocks.J
     lcon = G_blocks.lcon
@@ -971,25 +971,8 @@ function _build_condensed_H_blocks(block_Q, block_R, block_A, block_B, block_S, 
 end
 
 
-function _build_condensed_G_blocks(block_A, block_B, block_E, block_F, block_K, block_gl, block_gu, s0, N, K::MK) where MK <: Nothing
-  
-    G = zeros(size(block_F))
-  
-    As0  = zeros(size(block_A, 1), 1)
-    EAs0 = zeros(size(block_E, 1), 1)
 
-    LinearAlgebra.mul!(G, block_E, block_B)
-    LinearAlgebra.axpy!(1, block_F, G)
-
-    LinearAlgebra.mul!(As0, block_A, s0)
-    LinearAlgebra.mul!(EAs0, block_E, As0)
-    LinearAlgebra.axpy!(-1, EAs0, block_gl)
-    LinearAlgebra.axpy!(-1, EAs0, block_gu)
-  
-    return (J = G, lcon = vec(block_gl), ucon = vec(block_gu), As0 = As0)
-end
-
-function _build_condensed_G_blocks(block_A, block_B, block_E, block_F, block_K, block_gl, block_gu, s0, N, K::MK) where MK <: AbstractMatrix
+function _build_condensed_G_blocks(block_A, block_B, block_E, block_F, block_K, block_gl, block_gu, s0, N)
   
     G = zeros(size(block_F))
   

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -45,7 +45,7 @@ Attributes include:
 
 see also `LQDynamicData(s0, A, B, Q, R, N; ...)`
 """
-struct LQDynamicData{T,V,M} <: AbstractLQDynData{T,V}
+struct LQDynamicData{T, V, M, MK} <: AbstractLQDynData{T,V}
     s0::V
     A::M
     B::M
@@ -54,11 +54,12 @@ struct LQDynamicData{T,V,M} <: AbstractLQDynData{T,V}
     N
 
     Qf::M
-    S::Union{M, Nothing}
+    S::M
     ns::Int
     nu::Int
     E::M
     F::M
+    K::MK
 
     sl::V
     su::V
@@ -69,7 +70,7 @@ struct LQDynamicData{T,V,M} <: AbstractLQDynData{T,V}
 end
 
 """
-    LQDynamicData(s0, A, B, Q, R, N; ...) -> LQDynamicData{T, V, M}
+    LQDynamicData(s0, A, B, Q, R, N; ...) -> LQDynamicData{T, V, M, MK}
 A constructor for building an object of type `LQDynamicData` for the optimization problem 
 ```math
     minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
@@ -110,9 +111,10 @@ function LQDynamicData(
     N;
 
     Qf::M = Q, 
-    S::Union{M, Nothing}  = nothing,
+    S::M  = zeros(size(Q, 1), size(R, 1)),
     E::M  = zeros(0, length(s0)),
     F::M  = zeros(0, size(R, 1)),
+    K::MK = nothing,
 
     sl::V = (similar(s0) .= -Inf),
     su::V = (similar(s0) .=  Inf),
@@ -120,7 +122,7 @@ function LQDynamicData(
     uu::V = (similar(s0, size(R,1)) .=  Inf),
     gl::V = fill(-Inf, size(E, 1)),
     gu::V = fill(Inf, size(F, 1))
-    ) where {T,V <: AbstractVector{T}, M <: AbstractMatrix{T}}
+    ) where {T,V <: AbstractVector{T}, M <: AbstractMatrix{T}, MK <: Union{Nothing, AbstractMatrix{T}}}
 
     if size(Q, 1) != size(Q, 2) 
         error("Q matrix is not square")
@@ -166,9 +168,12 @@ function LQDynamicData(
     if length(gu) != size(E, 1)
         error("Dimensions of gu do not match E and F")
     end
-    if S != nothing
-        if size(S, 1) != size(Q, 1) || size(S, 2) != size(R, 1)
-            error("Dimensions of S do not match dimensions of Q and R")
+    if size(S, 1) != size(Q, 1) || size(S, 2) != size(R, 1)
+        error("Dimensions of S do not match dimensions of Q and R")
+    end
+    if K != nothing
+        if size(K, 1) != size(R, 1) || size(K, 2) != size(Q,1)
+            error("Dimensions of K  do not match number of states and inputs")
         end
     end
 
@@ -176,9 +181,9 @@ function LQDynamicData(
     ns = size(Q,1)
     nu = size(R,1)
 
-    LQDynamicData{T,V,M}(
+    LQDynamicData{T, V, M, MK}(
         s0, A, B, Q, R, N,
-        Qf, S, ns, nu, E, F,
+        Qf, S, ns, nu, E, F, K,
         sl, su, ul, uu, gl, gu
     )
 end
@@ -187,11 +192,11 @@ end
 
 abstract type AbstractDynamicModel{T,V} <: QuadraticModels.AbstractQuadraticModel{T, V} end
 
-mutable struct LQDynamicModel{T, V, M1, M2, M3} <:  AbstractDynamicModel{T,V} 
+mutable struct LQDynamicModel{T, V, M1, M2, M3, MK} <:  AbstractDynamicModel{T,V} 
   meta::NLPModels.NLPModelMeta{T, V}
   counters::NLPModels.Counters
   data::QuadraticModels.QPData{T, V, M1, M2}
-  dynamic_data::LQDynamicData{T, V, M3}
+  dynamic_data::LQDynamicData{T, V, M3, MK}
   condense::Bool
 end
 
@@ -232,7 +237,7 @@ If `condense=true`, data is converted to the form
 
 Resulting `H`, `J`, `h`, and `h0` matrices are stored within `QuadraticModels.QPData` as `H`, `A`, `c`, and `c0` attributes respectively
 """
-function LQDynamicModel(dnlp::LQDynamicData{T,V,M}; condense = false) where {T, V <: AbstractVector{T}, M  <: AbstractMatrix{T}}
+function LQDynamicModel(dnlp::LQDynamicData{T,V,M}; condense = false) where {T, V <: AbstractVector{T}, M  <: AbstractMatrix{T}, MK <: Union{Nothing, AbstractMatrix{T}}}
 
     if condense==false
         _build_sparse_lq_dynamic_model(dnlp)
@@ -252,9 +257,10 @@ function LQDynamicModel(
     R::M,
     N;
     Qf::M = Q, 
-    S::Union{M, Nothing}  = nothing,
+    S::M  = zeros(size(Q, 1), size(R, 1)),
     E::M  = zeros(0, length(s0)),
     F::M  = zeros(0, size(R, 1)),
+    K::MK = nothing,
     sl::V = (similar(s0) .= -Inf),
     su::V = (similar(s0) .=  Inf),
     ul::V = (similar(s0,size(R, 1)) .= -Inf),
@@ -262,16 +268,16 @@ function LQDynamicModel(
     gl::V = fill(-Inf, size(E, 1)),
     gu::V = fill(Inf, size(F, 1)),
     condense=false
-    ) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}}
+    ) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}, MK <: Union{Nothing, AbstractMatrix{T}}}
 
-    dnlp = LQDynamicData(s0, A, B, Q, R, N; Qf = Qf, S = S, E = E, F = F, sl = sl, su = su, ul = ul, uu = uu, gl = gl, gu = gu)
+    dnlp = LQDynamicData(s0, A, B, Q, R, N; Qf = Qf, S = S, E = E, F = F, K = K, sl = sl, su = su, ul = ul, uu = uu, gl = gl, gu = gu)
     
     LQDynamicModel(dnlp; condense=condense)
 
 end
 
-function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T,V,M}) where {T, V <: AbstractVector{T}, M  <: AbstractMatrix{T}}
-    s0 = dnlp.s0
+function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where {T, V <: AbstractVector{T}, M  <: AbstractMatrix{T}, MK <: Nothing}
+    s0 = dnlp.s0, 
     A  = dnlp.A
     B  = dnlp.B
     Q  = dnlp.Q
@@ -359,7 +365,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T,V,M}) where {T, V 
 
 end
 
-function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M}) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}}
+function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where {T, V <: AbstractVector{T}, M  <: AbstractMatrix{T}, MK <: Abstract_Matrix}
     s0 = dnlp.s0
     A  = dnlp.A
     B  = dnlp.B
@@ -373,6 +379,7 @@ function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M}) where {T,
     nu = dnlp.nu
     E  = dnlp.E
     F  = dnlp.F
+    K  = dnlp.K
 
     sl = dnlp.sl
     su = dnlp.su
@@ -381,14 +388,142 @@ function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M}) where {T,
     gl = dnlp.gl
     gu = dnlp.gu
 
-    
-    condensed_blocks = _build_condensed_blocks(s0, Q, R, A, B, N; Qf = Qf, S = S)
+    # Transform u variables to v variables
+    new_Q = copy(Q)
+    new_S = sopy(S)
+    new_A = copy(A)
+    new_E = copy(E)
 
-    block_A = condensed_blocks.block_A
-    block_B = condensed_blocks.block_B
-    H       = condensed_blocks.H
-    c       = condensed_blocks.c
-    c0      = condensed_blocks.c0
+    KTR  = zeros(size(K, 2), size(R, 2))
+    LinearAlgebra.mul!(KTR, transpose(K), R)
+    LinearAlgebra.axpy!(1, KTR, new_S)
+
+    SK   = zeros(size(S, 1), size(K, 2))
+    KTRK = zeros(size(K, 2), size(K, 2)) 
+    LinearAlgebra.mul!(SK, S, K)
+    LinearAlgebra.mul!(KTRK, KTR, K)
+    LinearAlgebra.axpy!(1, SK, new_Q)
+    LinearAlgebra.axpy!(1, transpose(SK), new_Q)
+    LinearAlgebra.axpy!(1, KTRK, new_Q)
+
+    BK    = zeros(size(B, 1), size(K, 2))
+    LinearAlgebra.mul!(BK, B, K)
+    LinearAlgebra.axpy!(1, BK, new_A)
+
+    FK    = zeros(size(F, 1), size(K, 2))
+    LinearAlgebra.mul!(FK, F, K)
+    LinearAlgebra.axpy!(1, FK, new_E)
+    
+    # Get H and J matrices from new matrices
+    H   = _build_H(new_Q, R, N; Qf = Qf, S = new_S)
+    J1  = _build_sparse_J1(new_A, B, N)
+    J2  = _build_sparse_J2(new_E, F, N)
+    J3, lcon3, ucon3  = _build_sparse_J3(K, N, uu, ul)
+
+    J   = vcat(J1, J2)
+    J   = vcat(J, J3)
+    
+    nvar = ns * (N + 1) + nu * N
+    
+    lvar  = fill(-Inf, nvar)
+    uvar  = fill(Inf, nvar)
+
+    lvar[1:ns] .= s0
+    uvar[1:ns] .= s0
+
+    ucon  = zeros(ns * N + N * length(gl))
+    lcon  = zeros(ns * N + N * length(gl))
+
+    ncon  = size(J, 1)
+    nnzj = length(J.rowval)
+    nnzh = length(H.rowval)
+
+    for i in 1:N
+        lvar[(i * ns + 1):((i + 1) * ns)] .= sl
+        uvar[(i * ns + 1):((i + 1) * ns)] .= su
+
+        lcon[(ns * N + 1 + (i -1) * length(gl)):(ns * N + i * length(gl))] .= gl
+        ucon[(ns * N + 1 + (i -1) * length(gl)):(ns * N + i * length(gl))] .= gu
+    end
+
+    lcon = vcat(lcon, lcon3)
+    ucon = vcat(ucon, ucon3)
+
+    c0 = 0.0
+    c  = zeros(nvar)
+
+    LQDynamicModel(
+        NLPModels.NLPModelMeta(
+        nvar,
+        lvar = lvar,
+        uvar = uvar, 
+        ncon = ncon,
+        lcon = lcon,
+        ucon = ucon,
+        nnzj = nnzj,
+        nnzh = nnzh,
+        lin = 1:ncon,
+        islp = (ncon == 0);
+        ),
+        NLPModels.Counters(),
+        QuadraticModels.QPData(
+        c0, 
+        c,
+        H,
+        J
+        ),
+        dnlp,
+        false
+    )
+end
+
+
+function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}, MK <: Nothing}
+    s0 = dnlp.s0
+    A  = dnlp.A
+    B  = dnlp.B
+    Q  = dnlp.Q
+    R  = dnlp.R
+    N  = dnlp.N
+
+    Qf = dnlp.Qf
+    S  = dnlp.S
+    ns = dnlp.ns
+    nu = dnlp.nu
+    E  = dnlp.E
+    F  = dnlp.F
+    K  = dnlp.K
+
+    sl = dnlp.sl
+    su = dnlp.su
+    ul = dnlp.ul
+    uu = dnlp.uu
+    gl = dnlp.gl
+    gu = dnlp.gu
+
+
+    condensed_blocks = _build_condensed_blocks(s0, Q, R, A, B, E, F, N, gu, gl; Qf = Qf, S = S)
+    block_A  = condensed_blocks.A
+    block_B  = condensed_blocks.B
+    block_Q  = condensed_blocks.Q
+    block_R  = condensed_blocks.R
+    block_E  = condensed_blocks.E
+    block_F  = condensed_blocks.F
+    block_S  = condensed_blocks.S
+    block_gl = condensed_blocks.gl
+    block_gu = condensed_blocks.gu
+
+    H_blocks = _build_condensed_H_blocks(block_Q, block_R, block_A, block_B, block_S, s0, N, K)
+
+    H  = H_blocks.H
+    c  = H_blocks.c
+    c0 = H_blocks.c0
+
+    G_blocks = _build_condensed_G_blocks(block_A, block_B, block_E, block_F, block_gl, block_gu, s0, N, K)
+
+    J     = H_blocks.J
+    lcon = H_blocks.lcon
+    ucon = H_blocks.ucon
 
     lvar = zeros(nu * N)
     uvar = zeros(nu * N)
@@ -398,34 +533,7 @@ function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M}) where {T,
         uvar[((i - 1) * nu + 1):(i * nu)] = uu
     end
 
-
-    nE1 = size(E, 1)
-    nE2 = size(E, 2)
-    nF1 = size(F, 1)
-    nF2 = size(F, 2)
-    ng  = length(gl)
-
-    
-    block_E  = zeros(nE1 * N, nE2 * (N + 1))
-    block_F  = zeros(nF1 * N, nF2 * N)
-    block_gl = zeros(ng * N, 1)
-    block_gu = zeros(ng * N, 1)
-  
-    for i in 1:N
-        block_E[((i - 1) * nE1 + 1):(i * nE1), ((i - 1) * nE2 + 1):(i * nE2)] .= E
-        block_F[((i - 1) * nF1 + 1):(i * nF1), ((i - 1) * nF2 + 1):(i * nF2)] .= F
-        block_gl[((i - 1) * ng  + 1):(i * ng)]  .= gl
-        block_gu[((i - 1) * ng  + 1):(i * ng)]  .= gu
-    end
-
-
-    condensed_blocks_G = _build_condensed_G(block_A, block_B, block_E, block_F, block_gl, block_gu, s0, N)
-
-    J1    = condensed_blocks_G.J
-    lcon1 = condensed_blocks_G.lcon
-    ucon1 = condensed_blocks_G.ucon
-    As0   = condensed_blocks_G.As0
-
+    # Convert state variable constraints to algebraic constraints
     bool_vec        = (su .!= Inf .|| sl .!= -Inf)
     num_real_bounds = sum(bool_vec)
 
@@ -446,15 +554,8 @@ function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M}) where {T,
         su = su[bool_vec]
     end
 
-
-    lcon  = zeros(length(lcon1) + size(J2,1))
-    ucon  = zeros(length(ucon1) + size(J2,1))
-
     lcon2 = zeros(size(J2, 1),1)
     ucon2 = zeros(size(J2, 1),1)
-
-    lcon[1:length(lcon1)] .= lcon1
-    ucon[1:length(ucon1)] .= ucon1
 
 
     for i in 1:N
@@ -465,8 +566,8 @@ function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M}) where {T,
     LinearAlgebra.axpy!(-1, As0_bounds, ucon2)
     LinearAlgebra.axpy!(-1, As0_bounds, lcon2)
 
-    lcon[(length(lcon1) + 1):end] .= lcon2
-    ucon[(length(ucon1) + 1):end] .= ucon2
+    lcon = vcat(lcon, lcon2)
+    ucon = vcat(ucon, ucon2)
 
     J = vcat(J1, J2)
 
@@ -501,12 +602,166 @@ function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M}) where {T,
     )
 end
 
+function _build_condensed_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}, MK <: AbstractMatrix{T}}
+    s0 = dnlp.s0
+    A  = dnlp.A
+    B  = dnlp.B
+    Q  = dnlp.Q
+    R  = dnlp.R
+    N  = dnlp.N
+
+    Qf = dnlp.Qf
+    S  = dnlp.S
+    ns = dnlp.ns
+    nu = dnlp.nu
+    E  = dnlp.E
+    F  = dnlp.F
+    K  = dnlp.K
+
+    sl = dnlp.sl
+    su = dnlp.su
+    ul = dnlp.ul
+    uu = dnlp.uu
+    gl = dnlp.gl
+    gu = dnlp.gu
+
+
+    condensed_blocks = _build_condensed_blocks(s0, Q, R, A, B, E, F, N, gu, gl; Qf = Qf, S = S)
+    block_A  = condensed_blocks.A
+    block_B  = condensed_blocks.B
+    block_Q  = condensed_blocks.Q
+    block_R  = condensed_blocks.R
+    block_E  = condensed_blocks.E
+    block_F  = condensed_blocks.F
+    block_S  = condensed_blocks.S
+    block_gl = condensed_blocks.gl
+    block_gu = condensed_blocks.gu
+
+    H_blocks = _build_condensed_H_blocks(block_Q, block_R, block_A, block_B, block_S, s0, N, K)
+
+    H  = H_blocks.H
+    c  = H_blocks.c
+    c0 = H_blocks.c0
+
+    G_blocks = _build_condensed_G_blocks(block_A, block_B, block_E, block_F, block_gl, block_gu, s0, N, K)
+
+    J     = H_blocks.J
+    lcon = H_blocks.lcon
+    ucon = H_blocks.ucon
+
+    # Convert state variable constraints to algebraic constraints
+    bool_vec_s        = (su .!= Inf .|| sl .!= -Inf)
+    num_real_bounds   = sum(bool_vec_s)
+
+    if num_real_bounds == length(sl)
+        J2         = block_B[(1 + ns):end,:]
+        As0_bounds = As0[(1 + ns):end,1]
+    else        
+        J2         = zeros(num_real_bounds * N, nu * N)
+        As0_bounds = zeros(num_real_bounds * N, 1)
+        for i in 1:N
+            row_range = (1 + (i - 1) * num_real_bounds):(i * num_real_bounds)
+            J2[row_range, :] = block_B[(1 + ns * i): (ns * (i + 1)), :][bool_vec_s, :]
+            As0_bounds[row_range, :] = As0[(1 + ns * i):(ns * (i + 1)), :][bool_vec_s, :]
+        end
+
+        sl = sl[bool_vec_s]
+        su = su[bool_vec_s]
+    end
+
+    # Convert bounds on u to algebraic constraints
+    bool_vec_u       = (ul .!= -Inf .|| uu .!= Inf)
+    num_real_bounds = sum(bool_vec_u)
+
+    KBI  = zeros(nu * N, nu * N)
+    KAs0 = zeros(nu * N, 1)
+    I_mat = 1.0Matrix(LinearAlgebra.I, nu * N, nu * N)
+
+    LinearAlgebra.mul!(KBI, block_K, block_B)
+    LinearAlgebra.axpy!(1, I_mat, KBI)
+    LinearAlgebra.mul!(KAs0, block_K, As0)
+
+    if num_real_bounds == length(ul)
+        J3 = KBI
+        KAs0_bounds = KAs0
+    else
+        J3          = zeros(num_real_bounds * N, nu * N)
+        KAs0_bounds = zeros(num_real_bounds * N, 1)
+        for i in 1:N
+            row_range   = (1 + (i - 1) * num_real_bounds):(i * num_real_bounds)
+            J3[row_range, :] = KBI[(1 + nu * (i - 1)):(nu * i), :][bool_vec_u, :]
+            KAs0_bounds[row_range, :]      = KAs0[(1 + nu * (i - 1)):(nu * i), 1][bool_vec_u,1]
+        end
+
+        ul = ul[bool_vec3]
+        uu = uu[bool_vec3]
+    end
+
+    lcon2 = zeros(size(J2, 1), 1)
+    ucon2 = zeros(size(J2, 1), 1)
+
+    lcon3 = zeros(size(J3, 1), 1)
+    ucon3 = zeros(size(J3, 1), 1)
+
+    for i in 1:N
+        lcon2[((i - 1) * length(su) + 1):(i * length(su)),1] = sl
+        ucon2[((i - 1) * length(su) + 1):(i * length(su)),1] = su
+
+        lcon3[((i - 1) * length(uu) + 1):(i * length(uu)),1] = ul
+        lcon3[((i - 1) * length(uu) + 1):(i * length(uu)),1] = uu
+    end
+
+    LinearAlgebra.axpy!(-1, As0_bounds, lcon2)
+    LinearAlgebra.axpy!(-1, As0_bounds, ucon2)
+
+    LinearAlgebra.axpy!(-1, KAs0_bounds, lcon2)
+    LinearAlgebra.axpy!(-1, KAs0_bounds, ucon2)
+
+    lcon = vcat(lcon, lcon2)
+    lcon = vcat(lcon, lcon3)
+
+    ucon = vcat(ucon, ucon2)
+    ucon = vcat(ucon, ucon3)
+
+    J = vcat(J1, J2)
+    J = vcat(J, J3)
+
+    nvar = nu * N
+    nnzj = size(J, 1) * size(J, 2)
+    nnzh = sum(LinearAlgebra.LowerTriangular(H) .!= 0)
+    ncon = size(J, 1)
+
+
+    LQDynamicModel(
+        NLPModels.NLPModelMeta(
+        nvar,
+        ncon = ncon,
+        lcon = lcon,
+        ucon = ucon,
+        nnzj = nnzj,
+        nnzh = nnzh,
+        lin = 1:ncon,
+        islp = (ncon == 0);
+        ),
+        NLPModels.Counters(),
+        QuadraticModels.QPData(
+        c0, 
+        c,
+        H,
+        J
+        ),
+        dnlp,
+        true
+    )
+end
+
 
 function _build_condensed_blocks(
-    s0, Q, R, A, B, N;
+    s0, Q, R, A, B, E, F, N, gu, gl;
     Qf = Q, 
-    S = nothing)
-  
+    S = zeros(size(Q, 1), size(R, 1))
+    )
+    
     ns = size(Q, 1)
     nu = size(R, 1)
   
@@ -515,108 +770,197 @@ function _build_condensed_blocks(
     block_A = zeros(ns * (N + 1), ns)
     block_Q = SparseArrays.sparse([],[], eltype(Q)[], ns * (N + 1), ns * (N + 1))
     block_R = SparseArrays.sparse([],[], eltype(R)[], nu * N, nu * N)
+    block_S = SparseArrays.sparse([],[], eltype(S)[], ns * (N + 1), nu * N)
+
+    nE1 = size(E, 1)
+    nE2 = size(E, 2)
+    nF1 = size(F, 1)
+    nF2 = size(F, 2)
+    
+    block_E  = zeros(nE1 * N, nE2 * (N + 1))
+    block_F  = zeros(nF1 * N, nF2 * N)
+    block_gl = zeros(nE1 * N, 1)
+    block_gu = zeros(nE1 * N, 1)
   
-    block_A[1:ns, 1:ns] .= Matrix(LinearAlgebra.I, ns, ns)
+    # Build E, F, and d (gl and gu) blocks
+    for i in 1:N
+        block_E[((i - 1) * nE1 + 1):(i * nE1), ((i - 1) * nE2 + 1):(i * nE2)] = E
+        block_F[((i - 1) * nF1 + 1):(i * nF1), ((i - 1) * nF2 + 1):(i * nF2)] = F
+        block_gl[((i - 1) * ng  + 1):(i * ng)]  = gl
+        block_gu[((i - 1) * ng  + 1):(i * ng)]  = gu
+    end
   
+    # Add diagonal of Bs and fill Q, R, S, and K block matrices
+    for j in 1:N
+        B_row_range = (j * ns + 1):((j + 1) * ns)
+        B_col_range = ((j - 1) * nu + 1):(j * nu)
+        block_B[B_row_range, B_col_range] = B
+  
+        block_Q[((j - 1) * ns + 1):(j * ns), ((j - 1) * ns + 1):(j * ns)] = Q
+        block_R[((j - 1) * nu + 1):(j * nu), ((j - 1) * nu + 1):(j * nu)] = R
+
+        S_row_range = (1 + ns * (j - 1)):(ns * j)
+        S_col_range = (1 + nu * (j - 1)):(nu * j)
+        
+        block_S[S_row_range, S_col_range] = S
+    end
+
+    block_A[1:ns, 1:ns] = Matrix(LinearAlgebra.I, ns, ns)
+  
+    A_k = copy(A)
+    BK  = zeros(size(B, 1), size(K, 2))
+    LinearAlgebra.mul!(BK, B, K)
+    LinearAlgebra.axpy!(1, BK, A_k)
+
     # Define matrices for mul!
-    A_klast  = copy(A)
-    A_k      = zeros(size(A))
+    A_klast  = copy(A_k)
+    A_knext  = copy(A_k)
     AB_klast = zeros(size(B))
     AB_k     = zeros(size(B))
-  
-    # Add diagonal of Bs and fill Q and R block matrices
-    for j in 1:N
-        row_range = (j * ns + 1):((j + 1) * ns)
-        col_range = ((j - 1) * nu+ 1):(j * nu)
-        block_B[row_range, col_range] .= B
-  
-        block_Q[((j - 1) * ns + 1):(j * ns), ((j - 1) * ns + 1):(j * ns)] .= Q
-        block_R[((j - 1) * nu + 1):(j * nu), ((j - 1) * nu + 1):(j * nu)] .= R
-    end
   
     # Fill the A and B matrices
     for i in 1:(N - 1)
         if i == 1
-            block_A[(ns + 1):ns*2, :] .= A
-            LinearAlgebra.mul!(AB_k, A, B)
+            block_A[(ns + 1):ns*2, :] = A_k
+            LinearAlgebra.mul!(AB_k, A_k, B)
             for k in 1:(N-i)
                 row_range = (1 + (k + 1) * ns):((k + 2) * ns)
                 col_range = (1 + (k - 1) * nu):(k * nu)
-                block_B[row_range, col_range] .= AB_k
+                block_B[row_range, col_range] = AB_k
             end
             AB_klast = copy(AB_k)
         else
-            LinearAlgebra.mul!(AB_k, A, AB_klast)
-            LinearAlgebra.mul!(A_k, A, A_klast)
-            block_A[(ns * i + 1):ns * (i + 1),:] .= A_k
+            LinearAlgebra.mul!(AB_k, A_k, AB_klast)
+            LinearAlgebra.mul!(A_knext, A_k, A_klast)
+            block_A[(ns * i + 1):ns * (i + 1),:] = A_knext
   
             for k in 1:(N-i)
                 row_range = (1 + (k + i) * ns):((k + i + 1) * ns)
                 col_range = (1 + (k - 1) * nu):(k * nu)
-                block_B[row_range, col_range] .= AB_k
+                block_B[row_range, col_range] = AB_k
             end
   
             AB_klast = copy(AB_k)
-            A_klast  = copy(A_k)
+            A_klast  = copy(A_knext)
         end
     end
+
+    LinearAlgebra.mul!(A_knext, A_k, A_klast)
+
+    block_A[(ns * N + 1):ns * (N + 1), :] = A_knext
+    block_Q[(ns * N + 1):((N + 1) * ns), (N * ns + 1):((N + 1) * ns)] = Qf
   
-
-    LinearAlgebra.mul!(A_k, A, A_klast)
-
-    block_A[(ns * N + 1):ns * (N + 1), :] .= A_k
-    block_Q[(ns * N + 1):((N + 1) * ns), (N * ns + 1):((N + 1) * ns)] .= Qf
-  
-    # build quadratic term
-    QB  = similar(block_B)
-    BQB = zeros(nu * N, nu * N)
-
-    LinearAlgebra.mul!(QB, block_Q, block_B)
-    LinearAlgebra.mul!(BQB, transpose(block_B), QB)
-    LinearAlgebra.axpy!(1, block_R, BQB)
-    
-    # build linear term 
-    h    = zeros(1, nu * N)
-    s0TAT = zeros(1, size(block_A,1))
-    LinearAlgebra.mul!(s0TAT, transpose(s0), transpose(block_A))
-    LinearAlgebra.mul!(h, s0TAT, QB)
-  
-    # build constant term 
-    QAs = zeros(size(s0TAT,2), size(s0TAT,1))
-    h0  = zeros(1,1)
-    LinearAlgebra.mul!(QAs, block_Q, transpose(s0TAT))
-    LinearAlgebra.mul!(h0, s0TAT, QAs)
-  
-    c0 = h0[1,1] / 2
-  
-    if S != nothing
-        if !iszero(S)
-            block_S = zeros(ns * (N + 1), nu * N)
-
-            for i in 1:N
-                row_range = (1 + ns * (i - 1)):(ns * i)
-                col_range = (1 + nu * (i - 1)):(nu * i)
-
-                block_S[row_range, col_range] = S
-            end        
-
-            BTS      = zeros(nu * N, nu * N)
-            s0T_AT_S = zeros(1, nu * N)
-
-            LinearAlgebra.mul!(BTS, transpose(block_B), block_S)
-
-            LinearAlgebra.axpy!(1, BTS, BQB)
-            LinearAlgebra.axpy!(1, transpose(BTS), BQB)
-
-            LinearAlgebra.mul!(s0T_AT_S, s0TAT, block_S)
-            LinearAlgebra.axpy!(1, s0T_AT_S, h)
-        end
-    end
-  
-    return (H = BQB, c = vec(h), c0 = c0, block_A = block_A, block_B = block_B, block_Q = block_Q, block_R = block_R)
+    return (A = block_A, B = block_B, Q = block_Q, R = block_R, S = block_S, E = block_E, F = block_F, gl = block_gl, gu = block_gu)
 end
 
-function _build_condensed_G(block_A, block_B, block_E, block_F, block_gl, block_gu, s0, N)
+function _build_condensed_H_blocks(block_Q, block_R, block_A, block_B, block_S, s0, N, K::MK) where MK <: Nothing
+    As0      = zeros(size(block_A, 1), 1)
+    QB       = zeros(size(block_Q, 1), size(block_B, 2))
+    STB      = zeros(size(block_S, 2), size(block_B, 2))
+    B_Q_B    = zeros(size(block_B, 2), size(block_B, 2))
+
+    LinearAlgebra.mul!(As0, block_A, s0)
+    LinearAlgebra.mul!(QB, block_Q, block_B)
+    LinearAlgebra.mul!(STB, transpose(block_S), block_B)
+    LinearAlgebra.mul!(B_Q_B, transpose(block_B), QB)
+
+    # Define Hessian term so that H = B_Q_B
+    LinearAlgebra.axpy!(1, block_R, B_Q_B)
+    LinearAlgebra.axpy!(1, STB, B_Q_B)
+    LinearAlgebra.axpy!(1, transpose(STB), B_Q_B)
+
+    # Define linear term so that c = h
+    h = zeros(1, size(As0, 1))
+    LinearAlgebra.axpy!(1, block_S, QB)
+    LinearAlgebra.mul!(h, transpose(As0), QB)
+
+    # Define linear term so that c0 = h0
+    h0   = zeros(1,1)
+    QAs0 = zeros(size(block_Q, 1), 1)
+    LinearAlgebra.mul!(QAs0, block_Q, As0)
+    LinearALgebra.mul!(h0, transpose(As0), QAs0)
+
+    return (H = B_Q_B, c = h, c0 = h0)
+end
+
+function _build_condensed_H_blocks(block_Q, block_R, block_A, block_B, block_S, s0, N, K::MK) where MK <: AbstractMatrix
+
+    ns = size(K, 2)
+    nu = size(K, 1)
+
+    block_K = SparseArrays.sparse([],[], eltype(R)[], nu * N, ns * (N + 1))
+
+    for j in 1:N
+        row_range = ((j - 1) * nu + 1):(j * nu)
+        block_K[row_range, ((j - 1) * ns + 1):(j * ns)] = K
+    end
+
+
+    As0      = zeros(size(block_A, 1), 1)
+    RK       = zeros(size(block_R, 1), size(block_K, 2))
+    RKB      = zeros(size(block_R, 1), size(block_B, 2))
+    SK       = zeros(size(block_S, 1), size(block_K, 2))
+    SKB      = zeros(size(block_S, 1), size(block_B, 2))
+    STB      = zeros(size(block_S, 2), size(block_B, 2))
+    KTSTB    = zeros(size(block_K, 2), size(block_B, 2))
+    KTRK     = zeros(size(block_K, 2), size(block_K, 2))
+    QB       = zeros(size(block_Q, 1), size(block_B, 2))
+    KTRK_B   = zeros(size(block_K, 2), size(block_B, 2))
+    B_Q_B    = zeros(size(block_B, 2), size(block_B, 2))
+
+    LinearAlgebra.mul!(As0, block_A, s0)
+    LinearAlgebra.mul!(RK, block_R, block_K)
+    LinearAlgebra.mul!(RKB, RK, block_B)
+    LinearAlgebra.mul!(SK, block_S, block_K)
+    LinearAlgebra.mul!(SKB, SK, block_B)
+    LinearAlgebra.mul!(STB, transpose(block_S), block_B)
+    LinearAlgebra.mul!(KTSTB, transpose(block_K), STB)
+    LinearAlgebra.mul!(QB, block_Q, block_B)
+    LinearAlgebra.mul!(KTRK, transpose(K), RK)
+    LinearAlgebra.mul!(KTRK_B, KTRK, block_B)
+
+    LinearAlgebra.axpy!(1, KTRK_B, QB)
+    LinearAlgebra.axpy!(1, SKB, QB)
+    LinearAlgebra.axpy!(1, KTSTB, QB)  # QB now equals QB + KTRKB + SKB + KTSTB
+
+    # Define Hessian term so that H = B_Q_B
+    LinearAlgebra.mul!(B_Q_B, transpose(block_B), QB)
+    LinearAlgebra.axpy!(1, block_R, B_Q_B)
+    LinearAlgebra.axpy!(1, transpose(RKB), B_Q_B)
+    LinearAlgebra.axpy!(1, RKB, B_Q_B)
+    LinearAlgebra.axpy!(1, STB, B_Q_B)
+    LinearAlgebra.axpy!(1, transpose(STB), B_Q_B)
+
+    # Define linear term so that c = h
+    h = zeros(1, nu * N)
+    LinearAlgebra.axpy!(1, block_S, QB)
+    LinearAlgebra.axpy!(1, transpose(RK), QB)
+    LinearAlgebra.mul!(h, transpose(As0), QB)
+
+    # Define constant term sot hat c0 = h0
+    hR_term = zeros(1, 1) # = s0^T A^T K^T R K A s0
+    hS_term = zeros(1, 1) # = s0^T A^T K^T S^T A s0 = s0^T A^T S K A s0
+    hQ_term = zeros(1, 1) # = s0^T A^T Q A s0
+
+    KTRKAs0 = zeros(size(K, 2), 1)
+    SKAs0   = zeros(size(S, 1), 1)
+    QAs0    = zeros(size(Q, 1), 1)
+
+    LinearAlgebra.mul!(KTRKAs0, KTRK, As0)
+    LinearAlgebra.mul!(SKAs0, SK, As0)
+    LinearAlgebra.mul!(QAs0, block_Q, As0)
+
+    LinearAlgebra.mul!(hR_term, transpose(As0), KTRKAs0)
+    LinearAlgebra.mul!(hS_term, transpose(As0), SKAs0)
+    LinearAlgebra.mul!(hQ_term, transpose(As0), QAs0)
+    
+    h0 = 1 / 2 * hR_term + 1 / 2 * hQ_term + hS_term
+
+    return (H = B_Q_B, c = h, c0 = h0)
+end
+
+
+function _build_condensed_G_blocks(block_A, block_B, block_E, block_F, block_gl, block_gu, s0, N, K::MK) where MK <: Nothing
   
     G = zeros(size(block_F))
   
@@ -631,7 +975,38 @@ function _build_condensed_G(block_A, block_B, block_E, block_F, block_gl, block_
     LinearAlgebra.axpy!(-1, EAs0, block_gl)
     LinearAlgebra.axpy!(-1, EAs0, block_gu)
   
-    return (J = G, lcon = vec(block_gl), ucon = vec(block_gu), As0 = As0)
+    return (J = G, lcon = vec(block_gl), ucon = vec(block_gu))
+end
+
+function _build_condensed_G_blocks(block_A, block_B, block_E, block_F, block_gl, block_gu, s0, N, K::MK) where MK <: AbstractMatrix
+  
+    ns = size(K, 2)
+    nu = size(K, 1)
+
+    block_K = SparseArrays.sparse([],[], eltype(R)[], nu * N, ns * (N + 1))
+
+    for j in 1:N
+        row_range = ((j - 1) * nu + 1):(j * nu)
+        block_K[row_range, ((j - 1) * ns + 1):(j * ns)] = K
+    end
+
+    G = zeros(size(block_F))
+  
+    As0  = zeros(size(block_A, 1), 1)
+    EAs0 = zeros(size(block_E, 1), 1)
+    FK   = zeros(size(block_F, 1), size(block_K, 2))
+
+    LinearAlgebra.mul!(FK, block_F, block_K)
+    LinearAlgebra.axpy!(1, FK, block_E)
+    LinearAlgebra.mul!(G, block_E, block_B)
+    LinearAlgebra.axpy!(1, block_F, G)
+
+    LinearAlgebra.mul!(As0, block_A, s0)
+    LinearAlgebra.mul!(EAs0, block_E, As0)
+    LinearAlgebra.axpy!(-1, EAs0, block_gl)
+    LinearAlgebra.axpy!(-1, EAs0, block_gu)
+  
+    return (J = G, lcon = vec(block_gl), ucon = vec(block_gu))
 end
 
 for field in fieldnames(LQDynamicData)
@@ -921,4 +1296,87 @@ function _build_sparse_J2(E, F, N)
 
 end
 
+function _build_sparse_J3(K, N, uu, ul)
+
+    # Remove algebraic constraints if u variable is unbounded on both upper and lower ends
+    nu = length(ul)
+    ns = size(K, 2)
+
+    bool_vec        = (ul .!= -Inf .|| uu != Inf)
+    num_real_bounds = sum(bool_vec)
+
+    J3 = SparseArrays.sparse([],[],eltype(K)[], ns * (N + 1) + nu * N, nu * N)
+    I_mat = Matrix(LinearAlgebra.I, nu, nu)
+
+    full_bool_vec = fill(true, nu * N)
+
+    lcon3 = zeros(nu * N)
+    ucon3 = zeros(nu * N)
+
+    for i in 1:N
+        row_range   = (nu * (i - 1) + 1):(nu * i)
+        K_col_range = (ns * (i - 1) + 1):(ns * i)
+        I_col_range = (ns * (N + 1) + 1 + nu * (i - 1)):(ns * (N + 1) + nu * i)
+        J3[row_range, K_col_range] = K
+        J3[row_range, I_col_range] = I_mat
+
+        lcon3[row_range] = ul
+        ucon3[row_range] = uu
+        full_bool_vec[row_range] = bool_vec
+    end
+
+    return J3[full_bool_vec, :], lcon3[full_bool_vec], ucon3[full_bool_vec]
+end
+
+
 end # module
+
+
+#=
+
+    # build quadratic term
+    QB  = similar(block_B)
+    BQB = zeros(nu * N, nu * N)
+
+    LinearAlgebra.mul!(QB, block_Q, block_B)
+    LinearAlgebra.mul!(BQB, transpose(block_B), QB)
+    LinearAlgebra.axpy!(1, block_R, BQB)
+    
+    # build linear term 
+    h    = zeros(1, nu * N)
+    s0TAT = zeros(1, size(block_A,1))
+    LinearAlgebra.mul!(s0TAT, transpose(s0), transpose(block_A))
+    LinearAlgebra.mul!(h, s0TAT, QB)
+  
+    # build constant term 
+    QAs = zeros(size(s0TAT,2), size(s0TAT,1))
+    h0  = zeros(1,1)
+    LinearAlgebra.mul!(QAs, block_Q, transpose(s0TAT))
+    LinearAlgebra.mul!(h0, s0TAT, QAs)
+  
+    c0 = h0[1,1] / 2
+  
+    if S != nothing
+        if !iszero(S)
+            block_S = zeros(ns * (N + 1), nu * N)
+
+            for i in 1:N
+                row_range = (1 + ns * (i - 1)):(ns * i)
+                col_range = (1 + nu * (i - 1)):(nu * i)
+
+                block_S[row_range, col_range] = S
+            end        
+
+            BTS      = zeros(nu * N, nu * N)
+            s0T_AT_S = zeros(1, nu * N)
+
+            LinearAlgebra.mul!(BTS, transpose(block_B), block_S)
+
+            LinearAlgebra.axpy!(1, BTS, BQB)
+            LinearAlgebra.axpy!(1, transpose(BTS), BQB)
+
+            LinearAlgebra.mul!(s0T_AT_S, s0TAT, block_S)
+            LinearAlgebra.axpy!(1, s0T_AT_S, h)
+        end
+    end
+    =#

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -430,11 +430,9 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     J2  = _build_sparse_J2(new_E, F, N)
     J3, lcon3, ucon3  = _build_sparse_J3(K, N, uu, ul)
 
-    println(size(J2))
-
     J   = vcat(J1, J2)
     J   = vcat(J, J3)
-    
+
     nvar = ns * (N + 1) + nu * N
     
     lvar  = fill(-Inf, nvar)

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -430,6 +430,8 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     J2  = _build_sparse_J2(new_E, F, N)
     J3, lcon3, ucon3  = _build_sparse_J3(K, N, uu, ul)
 
+    println(size(J2))
+
     J   = vcat(J1, J2)
     J   = vcat(J, J3)
     
@@ -1286,7 +1288,7 @@ function _build_sparse_J3(K, N, uu, ul)
     nu = length(ul)
     ns = size(K, 2)
 
-    bool_vec        = (ul .!= -Inf .|| uu != Inf)
+    bool_vec        = (ul .!= -Inf .|| uu .!= Inf)
     num_real_bounds = sum(bool_vec)
 
     J3 = SparseArrays.sparse([],[],eltype(K)[], nu * N, ns * (N + 1) + nu * N)
@@ -1312,55 +1314,4 @@ function _build_sparse_J3(K, N, uu, ul)
     return J3[full_bool_vec, :], lcon3[full_bool_vec], ucon3[full_bool_vec]
 end
 
-
 end # module
-
-
-#=
-
-    # build quadratic term
-    QB  = similar(block_B)
-    BQB = zeros(nu * N, nu * N)
-
-    LinearAlgebra.mul!(QB, block_Q, block_B)
-    LinearAlgebra.mul!(BQB, transpose(block_B), QB)
-    LinearAlgebra.axpy!(1, block_R, BQB)
-    
-    # build linear term 
-    h    = zeros(1, nu * N)
-    s0TAT = zeros(1, size(block_A,1))
-    LinearAlgebra.mul!(s0TAT, transpose(s0), transpose(block_A))
-    LinearAlgebra.mul!(h, s0TAT, QB)
-  
-    # build constant term 
-    QAs = zeros(size(s0TAT,2), size(s0TAT,1))
-    h0  = zeros(1,1)
-    LinearAlgebra.mul!(QAs, block_Q, transpose(s0TAT))
-    LinearAlgebra.mul!(h0, s0TAT, QAs)
-  
-    c0 = h0[1,1] / 2
-  
-    if S != nothing
-        if !iszero(S)
-            block_S = zeros(ns * (N + 1), nu * N)
-
-            for i in 1:N
-                row_range = (1 + ns * (i - 1)):(ns * i)
-                col_range = (1 + nu * (i - 1)):(nu * i)
-
-                block_S[row_range, col_range] = S
-            end        
-
-            BTS      = zeros(nu * N, nu * N)
-            s0T_AT_S = zeros(1, nu * N)
-
-            LinearAlgebra.mul!(BTS, transpose(block_B), block_S)
-
-            LinearAlgebra.axpy!(1, BTS, BQB)
-            LinearAlgebra.axpy!(1, transpose(BTS), BQB)
-
-            LinearAlgebra.mul!(s0T_AT_S, s0TAT, block_S)
-            LinearAlgebra.axpy!(1, s0T_AT_S, h)
-        end
-    end
-    =#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -357,14 +357,14 @@ lq_sparse_from_data   = LQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl,
 lq_condense_from_data = LQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K, condense=true)
 
 optimize!(model)
-solution_ref_sparse             = madnlp(lq_sparse, max_iter=150) 
-solution_ref_condense           = madnlp(lq_condense, max_iter=150)
-solution_ref_sparse_from_data   = madnlp(lq_sparse_from_data, max_iter=150)
-solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=150)
+solution_ref_sparse             = madnlp(lq_sparse, max_iter=100) 
+solution_ref_condense           = madnlp(lq_condense, max_iter=100)
+solution_ref_sparse_from_data   = madnlp(lq_sparse_from_data, max_iter=100)
+solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
 
-@test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-6
+@test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-7
 @test objective_value(model) ≈ solution_ref_condense.objective atol = 1e-5
-@test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-6
+@test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-7
 @test objective_value(model) ≈ solution_ref_condense_from_data.objective atol = 1e-5
 
 @test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -341,8 +341,8 @@ solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
 @test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-7
 @test objective_value(model) ≈ solution_ref_condense_from_data.objective atol = 1e-5
 
-@test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-6
-@test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-6
+@test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-5
+@test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-5
 
 
 
@@ -367,5 +367,5 @@ solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
 @test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-7
 @test objective_value(model) ≈ solution_ref_condense_from_data.objective atol = 1e-5
 
-@test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-6
-@test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-6
+@test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-5
+@test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -299,7 +299,7 @@ solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
 nu = 2 # number of inputs
 
 # generate random Q, R, A, and B matrices
-Random.seed!(10)
+Random.seed!(3)
 R_rand   = Random.rand(nu,nu)
 R    = R_rand * transpose(R_rand) + I
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,12 +8,12 @@ nu = 1 # number of inputs
 # generate random Q, R, A, and B matrices
 Random.seed!(10)
 Q_rand = Random.rand(ns, ns)
-Q = Q_rand * transpose(Q_rand) + I
+Q = Q_rand * Q_rand' + I
 R_rand   = Random.rand(nu,nu)
-R    = R_rand * transpose(R_rand) + I
+R    = R_rand * R_rand' + I
 
 A_rand = rand(ns, ns)
-A = A_rand * transpose(A_rand) + I
+A = A_rand * A_rand' + I
 B = rand(ns, nu)
 
 # generate upper and lower bounds
@@ -31,7 +31,7 @@ sl_with_inf[1] = -Inf
 
 
 Qf_rand = Random.rand(ns,ns)
-Qf = Qf_rand * transpose(Qf_rand) + I
+Qf = Qf_rand * Qf_rand' + I
 
 E  = rand(3, ns)
 F  = rand(3, nu)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,3 @@
-using Revise
 using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra
 include("sparse_lq_test.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -362,10 +362,11 @@ solution_ref_condense           = madnlp(lq_condense, max_iter=100)
 solution_ref_sparse_from_data   = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
 
-@test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-4
 @test objective_value(model) ≈ solution_ref_condense.objective atol = 1e-5
-@test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-4
 @test objective_value(model) ≈ solution_ref_condense_from_data.objective atol = 1e-5
 
 @test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-5
 @test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-5
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -357,14 +357,14 @@ lq_sparse_from_data   = LQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl,
 lq_condense_from_data = LQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K, condense=true)
 
 optimize!(model)
-solution_ref_sparse             = madnlp(lq_sparse, max_iter=100) 
-solution_ref_condense           = madnlp(lq_condense, max_iter=100)
-solution_ref_sparse_from_data   = madnlp(lq_sparse_from_data, max_iter=100)
-solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
+solution_ref_sparse             = madnlp(lq_sparse, max_iter=150) 
+solution_ref_condense           = madnlp(lq_condense, max_iter=150)
+solution_ref_sparse_from_data   = madnlp(lq_sparse_from_data, max_iter=150)
+solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=150)
 
-@test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-4
+@test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-6
 @test objective_value(model) ≈ solution_ref_condense.objective atol = 1e-5
-@test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-4
+@test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-6
 @test objective_value(model) ≈ solution_ref_condense_from_data.objective atol = 1e-5
 
 @test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Revise
 using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra
 include("sparse_lq_test.jl")
 
@@ -40,6 +41,7 @@ gu = fill(15.0, 3)
 
 S = rand(ns, nu)
 
+K = rand(nu, ns)
 
 
 # Test with no bounds
@@ -228,6 +230,132 @@ lq_sparse_from_data   = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su =
 lq_condense_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S, condense=true)
 
 optimize!(model)
+
+optimize!(model)
+solution_ref_sparse             = madnlp(lq_sparse, max_iter=100) 
+solution_ref_condense           = madnlp(lq_condense, max_iter=100)
+solution_ref_sparse_from_data   = madnlp(lq_sparse_from_data, max_iter=100)
+solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
+
+@test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_condense.objective atol = 1e-5
+@test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_condense_from_data.objective atol = 1e-5
+
+@test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-6
+@test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-6
+
+
+# Test K matrix case without S
+model       = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K)
+dnlp        = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K)
+lq_sparse   = LQDynamicModel(dnlp; condense=false)
+lq_condense = LQDynamicModel(dnlp; condense=true)
+
+lq_sparse_from_data   = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, condense=false)
+lq_condense_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, condense=true)
+
+optimize!(model)
+solution_ref_sparse             = madnlp(lq_sparse, max_iter=100) 
+solution_ref_condense           = madnlp(lq_condense, max_iter=100)
+solution_ref_sparse_from_data   = madnlp(lq_sparse_from_data, max_iter=100)
+solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
+
+@test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_condense.objective atol = 1e-5
+@test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_condense_from_data.objective atol = 1e-5
+
+@test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-6
+@test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-6
+
+
+
+# Test K matrix case with S
+model       = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
+dnlp        = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
+lq_sparse   = LQDynamicModel(dnlp; condense=false)
+lq_condense = LQDynamicModel(dnlp; condense=true)
+
+lq_sparse_from_data   = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S, condense=false)
+lq_condense_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S, condense=true)
+
+optimize!(model)
+solution_ref_sparse             = madnlp(lq_sparse, max_iter=100) 
+solution_ref_condense           = madnlp(lq_condense, max_iter=100)
+solution_ref_sparse_from_data   = madnlp(lq_sparse_from_data, max_iter=100)
+solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
+
+@test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_condense.objective atol = 1e-5
+@test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_condense_from_data.objective atol = 1e-5
+
+@test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-6
+@test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-6
+
+
+# Test K matrix case with S and with partial bounds on u
+
+nu = 2 # number of inputs
+
+# generate random Q, R, A, and B matrices
+Random.seed!(10)
+R_rand   = Random.rand(nu,nu)
+R    = R_rand * transpose(R_rand) + I
+
+B = rand(ns, nu)
+
+# generate upper and lower bounds
+ul = fill(-20.0, nu)
+uu = ul .+ 30
+
+ul_with_inf = copy(ul)
+uu_with_inf = copy(uu)
+
+uu_with_inf[1] = Inf
+ul_with_inf[1] = -Inf
+
+F  = rand(3, nu)
+
+S = rand(ns, nu)
+
+K = rand(nu, ns)
+
+
+model       = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
+dnlp        = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
+lq_sparse   = LQDynamicModel(dnlp; condense=false)
+lq_condense = LQDynamicModel(dnlp; condense=true)
+
+lq_sparse_from_data   = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S, condense=false)
+lq_condense_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S, condense=true)
+
+optimize!(model)
+solution_ref_sparse             = madnlp(lq_sparse, max_iter=100) 
+solution_ref_condense           = madnlp(lq_condense, max_iter=100)
+solution_ref_sparse_from_data   = madnlp(lq_sparse_from_data, max_iter=100)
+solution_ref_condense_from_data = madnlp(lq_condense_from_data, max_iter=100)
+
+@test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_condense.objective atol = 1e-5
+@test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-7
+@test objective_value(model) ≈ solution_ref_condense_from_data.objective atol = 1e-5
+
+@test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense.solution atol =  1e-6
+@test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_condense_from_data.solution atol =  1e-6
+
+
+
+
+# Test K with no bounds
+model       = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, E = E, F = F, gl = gl, gu = gu, K = K)
+dnlp        = LQDynamicData(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K)
+lq_sparse   = LQDynamicModel(dnlp; condense=false)
+lq_condense = LQDynamicModel(dnlp; condense=true)
+
+lq_sparse_from_data   = LQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K, condense=false)
+lq_condense_from_data = LQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K, condense=true)
 
 optimize!(model)
 solution_ref_sparse             = madnlp(lq_sparse, max_iter=100) 

--- a/test/sparse_lq_test.jl
+++ b/test/sparse_lq_test.jl
@@ -1,12 +1,9 @@
-
 """
     build_QP_JuMP_model(Q,R,A,B,N;...) -> JuMP.Model(...)
-
 Return a `JuMP.jl` Model for the quadratic problem 
     
 min 1/2 ( sum_{i=1}^{N-1} s_i^T Q s + sum_{i=1}^{N-1} u^T R u + s_N^T Qf s_n  )
 s.t. s_{i+1} = As_i + Bs_i for i = 1,..., N-1
-
 Optional Arguments
 - `Qf = []`: matrix multiplied by s_N in objective function (defaults to Q if not given)
 - `c = zeros(N*size(Q,1) + N*size(R,1)`:  linear term added to objective funciton, c^T z
@@ -15,7 +12,6 @@ Optional Arguments
 - `ul = fill(-Inf, size(Q,1))`: lower bound on input variables
 - `uu = fill(Inf,  size(Q,1))`: upper bound on input variables
 - `s0 = []`: initial state of the first state variables
-
 """
 function build_QP_JuMP_model(
         Q,R,A,B, N;
@@ -24,17 +20,14 @@ function build_QP_JuMP_model(
         su = [],
         ul = [],
         uu = [],
-        Qf = [],
+        Qf = Q,
         E  = [],
         F  = [],
         gl = [],
         gu = [],
-        S  = zeros(size(Q, 1), size(R, 1))
+        S  = zeros(size(Q, 1), size(R, 1)),
+        K  = zeros(size(R, 1), size(Q, 1))
         )
-
-    if size(Qf,1) == 0
-        Qf = copy(Q)
-    end
 
     ns = size(Q,1) # Number of states
     nu = size(R,1) # Number of inputs
@@ -48,8 +41,9 @@ function build_QP_JuMP_model(
     model = Model(MadNLP.Optimizer) # define model
 
 
-    @variable(model, s[NS, 0:N]) # define states 
+    @variable(model, s[NS, 0:N])     # define states 
     @variable(model, u[NU, 0:(N-1)]) # define inputs
+    @variable(model, v[NU, 0:(N-1)]) 
 
 
 
@@ -100,11 +94,17 @@ function build_QP_JuMP_model(
 
     # Give constraints from A, B, matrices
     @constraint(model, [t in 0:(N - 1), s1 in NS], s[s1, t + 1] == sum(A[s1, s2] * s[s2, t] for s2 in NS) + sum(B[s1, u1] * u[u1, t] for u1 in NU) )
+    
+    # Constraints for Kx + v = u
+    for u1 in NU
+        @constraint(model, [t in 0:(N - 1)], u[u1, t] == v[u1, t] + sum( K[u1, s1] * s[s1,t]  for s1 in NS))
+    end
 
     # Add E, F constraints
     if length(E) > 0
         for i in 1:size(E,1)
             @constraint(model,[t in 0:(N-1)], gl[i] <= sum(E[i, s1] * s[s1, t] for s1 in NS) + sum(F[i,u1] * u[u1, t] for u1 in NU))
+            @constraint(model,[t in 0:(N-1)], gu[i] >= sum(E[i, s1] * s[s1, t] for s1 in NS) + sum(F[i,u1] * u[u1, t] for u1 in NU))
         end
     end
 


### PR DESCRIPTION
Added both sparse and condensed support for `K` state elimination. 
 - Added attribute to `LQDynamicData` with new type for `K::MK`. This allows for multiple dispatch of different functions.
 - Redefined `_build_condensed_lq_dynamic_model` and `_build_sparse_lq_dynamic_model` for different types of `K`. The matrix `K` influences problem type and constraint and variable bounds. 
 - Transformed `A` and `E` matrices within `_build_sparse_lq_dynamic_model` for when `K` is defined. 
 - Added `_build_sparse_J3` function that is called within the `_build_sparse_lq_dynamic_model` when `K <: AbstractMatrix`. This converts $u$ variable bounds to algebraic constriants for $v$
 - Redefined `_build_condensed_blocks` to just build the block matrices of the condensed problems
 - Defined `_build_condensed_H_blocks` that returns `H`, `h`, and `h0`. Defined two forms of the function depending on `K` type
 - Defined `_build_condensed_G_blocks` that returns `J`, `lcon`, and `ucon`. 
 - Updated `sparse_lq_test.jl` to include a `K` matrix
 - Updated `runtests.jl` to test the problem with a `K` matrix, with a `K` matrix and `S` matrix, with a `K` matrix and `S` matrix and partial bounds on $u$, and with the `K` matrix and no bounds. 