### PR TITLE
Added support for non-default matrix types including `CuArray`s 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [targets]
-test = ["Test", "MadNLP", "JuMP", "Random", "CUDA"  ]
+test = ["Test", "MadNLP", "JuMP", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [targets]
-test = ["Test", "MadNLP", "JuMP", "Random"]
+test = ["Test", "MadNLP", "JuMP", "Random", "CUDA"  ]

--- a/Project.toml
+++ b/Project.toml
@@ -22,4 +22,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [targets]
-test = ["Test", "MadNLP", "JuMP", "Random", "CUDA"  ]
+test = ["Test", "MadNLP", "JuMP", "Random", "CUDA"]

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -328,7 +328,10 @@ function LQDynamicModel(
     dense=false
 ) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}, MK <: Union{Nothing, AbstractMatrix{T}}}
 
-    dnlp = LQDynamicData(s0, A, B, Q, R, N; Qf = Qf, S = S, E = E, F = F, K = K, sl = sl, su = su, ul = ul, uu = uu, gl = gl, gu = gu)
+    dnlp = LQDynamicData(
+        s0, A, B, Q, R, N; 
+        Qf = Qf, S = S, E = E, F = F, K = K, 
+        sl = sl, su = su, ul = ul, uu = uu, gl = gl, gu = gu)
     
     LQDynamicModel(dnlp; dense=dense)
 
@@ -368,17 +371,17 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
 
     
     nvar = ns * (N + 1) + nu * N
-    c  = (similar(Q, nvar) .= 0)
+    c  = similar(Q, nvar); fill!(c, 0)
     
-    lvar  = (similar(Q, nvar) .= 0)
-    uvar  = (similar(Q, nvar) .= 0)
+    lvar  = similar(Q, nvar); fill!(lvar, 0)
+    uvar  = similar(Q, nvar); fill!(uvar, 0)
 
     lvar[1:ns] .= s0
     uvar[1:ns] .= s0
 
 
-    ucon  = (similar(Q, ns * N + N * length(gl)) .= 0)
-    lcon  = (similar(Q, ns * N + N * length(gl)) .= 0)
+    lcon  = similar(Q, ns * N + N * length(gl)); fill!(lcon, 0)
+    ucon  = similar(Q, ns * N + N * length(gl)); fill!(ucon, 0)
 
     ncon  = size(J, 1)
     nnzj = length(J.rowval)
@@ -454,28 +457,28 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     new_A = similar(A)
     new_E = similar(E)
 
-    copyto!(new_Q, Q)
-    copyto!(new_S, S)
-    copyto!(new_A, A)
-    copyto!(new_E, E)
+    LinearAlgebra.copyto!(new_Q, Q)
+    LinearAlgebra.copyto!(new_S, S)
+    LinearAlgebra.copyto!(new_A, A)
+    LinearAlgebra.copyto!(new_E, E)
 
-    KTR  = (similar(Q, size(K, 2), size(R, 2)) .= 0)
+    KTR  = similar(Q, size(K, 2), size(R, 2))
     LinearAlgebra.mul!(KTR, K', R)
     LinearAlgebra.axpy!(1, KTR, new_S)
 
-    SK   = (similar(Q, size(S, 1), size(K, 2)) .= 0)
-    KTRK = (similar(Q, size(K, 2), size(K, 2)) .= 0)
+    SK   = similar(Q, size(S, 1), size(K, 2))
+    KTRK = similar(Q, size(K, 2), size(K, 2))
     LinearAlgebra.mul!(SK, S, K)
     LinearAlgebra.mul!(KTRK, KTR, K)
     LinearAlgebra.axpy!(1, SK, new_Q)
     LinearAlgebra.axpy!(1, SK', new_Q)
     LinearAlgebra.axpy!(1, KTRK, new_Q)
 
-    BK    = (similar(Q, size(B, 1), size(K, 2)) .= 0)
+    BK    = similar(Q, size(B, 1), size(K, 2))
     LinearAlgebra.mul!(BK, B, K)
     LinearAlgebra.axpy!(1, BK, new_A)
 
-    FK    = (similar(Q, size(F, 1), size(K, 2)) .= 0)
+    FK    = similar(Q, size(F, 1), size(K, 2))
     LinearAlgebra.mul!(FK, F, K)
     LinearAlgebra.axpy!(1, FK, new_E)
     
@@ -491,14 +494,14 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
 
     nvar = ns * (N + 1) + nu * N
     
-    lvar  = (similar(Q, nvar) .= -Inf)
-    uvar  = (similar(Q, nvar) .= Inf)
+    lvar  = similar(Q, nvar); fill!(lvar, -Inf)
+    uvar  = similar(Q, nvar); fill!(uvar, Inf)
 
     lvar[1:ns] .= s0
     uvar[1:ns] .= s0
 
-    ucon  = (similar(Q, ns * N + N * length(gl) + length(lcon3)) .= 0)
-    lcon  = (similar(Q, ns * N + N * length(gl) + length(lcon3)) .= 0)
+    lcon  = similar(Q, ns * N + N * length(gl) + length(lcon3)); fill!(lcon, 0)
+    ucon  = similar(Q, ns * N + N * length(gl) + length(lcon3)); fill!(ucon, 0)
 
     ncon  = size(J, 1)
     nnzj = length(J.rowval)
@@ -520,7 +523,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
 
 
     c0 = eltype(Q)(0.0)
-    c  = (similar(Q, nvar) .= 0)
+    c  = similar(Q, nvar); fill!(c, 0)
 
     SparseLQDynamicModel(
         NLPModels.NLPModelMeta(
@@ -596,8 +599,8 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
     ucon1 = G_blocks.ucon
     As0   = G_blocks.As0
 
-    lvar = (similar(Q, nu * N) .= 0)
-    uvar = (similar(Q, nu * N) .= 0)
+    lvar = similar(Q, nu * N); fill!(lvar, -Inf)
+    uvar = similar(Q, nu * N); fill!(uvar, Inf)
 
     for i in 1:(N)
         lvar[((i - 1) * nu + 1):(i * nu)] = ul
@@ -608,26 +611,25 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
     bool_vec        = (su .!= Inf .|| sl .!= -Inf)
     num_real_bounds = sum(bool_vec)
 
+    J2         = similar(Q, num_real_bounds * N, nu * N); fill!(J2, 0)
+    As0_bounds = similar(Q, num_real_bounds * N, 1); fill!(As0_bounds, 0)
+
     if num_real_bounds == length(sl)
-        J2         = (similar(Q, ns * N, nu * N) .= 0)
         J2        .= block_B[(1 + ns):end,:]
-        As0_bounds = As0[(1 + ns):end,1]
+        As0_bounds .= As0[(1 + ns):end,1]
     else        
-        J2         = (similar(Q, num_real_bounds * N, nu * N) .= 0)
-        As0_bounds = (similar(Q, num_real_bounds * N, 1) .= 0)
         for i in 1:N
             row_range = (1 + (i - 1) * num_real_bounds):(i * num_real_bounds)
             J2[row_range, :] .= block_B[(1 + ns * i): (ns * (i + 1)), :][bool_vec, :]
             As0_bounds[row_range, :] .= As0[(1 + ns * i):(ns * (i + 1)), :][bool_vec, :]
         end
 
-
         sl = sl[bool_vec]
         su = su[bool_vec]
     end
 
-    lcon2 = (similar(Q, size(J2, 1), 1) .= 0)
-    ucon2 = (similar(Q, size(J2, 1), 1) .= 0)
+    lcon2 = similar(Q, size(J2, 1), 1); fill!(lcon2, 0)
+    ucon2 = similar(Q, size(J2, 1), 1); fill!(ucon2, 0)
 
 
     for i in 1:N
@@ -638,8 +640,8 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
     LinearAlgebra.axpy!(-1, As0_bounds, ucon2)
     LinearAlgebra.axpy!(-1, As0_bounds, lcon2)
 
-    lcon = (similar(Q, length(lcon1) + length(lcon2)) .= 0)
-    ucon = (similar(Q, length(ucon1) + length(ucon2)) .= 0)
+    lcon = similar(Q, length(lcon1) + length(lcon2)); fill!(lcon, 0)
+    ucon = similar(Q, length(ucon1) + length(ucon2)); fill!(ucon, 0)
     
     lcon[1:length(lcon1)] .= lcon1
     ucon[1:length(ucon1)] .= ucon1
@@ -649,7 +651,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         ucon[(1 + length(ucon1)):end] .= ucon2
     end
 
-    J   = (similar(Q, size(J1, 1) + size(J2, 1), size(J1,2)) .= 0)
+    J   = similar(Q, size(J1, 1) + size(J2, 1), size(J1,2)); fill!(J, 0)
     J[1:(size(J1, 1)), :]   .= J1
     if size(J2, 1) > 0
         J[(1 + size(J1, 1)):end, :] .= J2
@@ -741,13 +743,14 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
     bool_vec_s        = (su .!= Inf .|| sl .!= -Inf)
     num_real_bounds   = sum(bool_vec_s)
 
+    J2         = similar(Q, num_real_bounds * N, nu * N); fill!(J2, 0)
+    As0_bounds = similar(Q, num_real_bounds * N, 1); fill!(As0_bounds, 0)
+
+
     if num_real_bounds == length(sl)
-        J2         = (similar(Q, ns * N, nu * N) .= 0)
         J2         .= block_B[(1 + ns):end,:]
-        As0_bounds = As0[(1 + ns):end,1]
+        As0_bounds .= As0[(1 + ns):end,1]
     else        
-        J2         = (similar(Q, num_real_bounds * N, nu * N) .= 0)
-        As0_bounds = (similar(Q, num_real_bounds * N, 1) .= 0)
         for i in 1:N
             row_range = (1 + (i - 1) * num_real_bounds):(i * num_real_bounds)
             J2[row_range, :] .= block_B[(1 + ns * i): (ns * (i + 1)), :][bool_vec_s, :]
@@ -762,37 +765,41 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
     bool_vec_u       = (ul .!= -Inf .|| uu .!= Inf)
     num_real_bounds = sum(bool_vec_u)
 
-    KBI  = (similar(Q, nu * N, nu * N) .= 0)
-    KAs0 = (similar(Q, nu * N, 1) .= 0)
+    KBI  = similar(Q, nu * N, nu * N)
+    KAs0 = similar(Q, nu * N, 1)
 
-    I_mat = (similar(Q, nu * N, nu * N) .= 0)
-    I_mat[LinearAlgebra.diagind(I_mat, 0)] .= 1.0
+    I_mat = similar(Q, nu * N, nu * N); fill!(I_mat, 0)
+
+    for i in 1:(nu * N)
+        I_mat[i, i] = 1.0
+    end
 
     LinearAlgebra.mul!(KBI, block_K, block_B)
     LinearAlgebra.axpy!(1, I_mat, KBI)
     LinearAlgebra.mul!(KAs0, block_K, As0)
 
+    J3          = similar(Q, num_real_bounds * N, nu * N); fill!(J3, 0)
+    KAs0_bounds = similar(Q, num_real_bounds * N, 1); fill!(KAs0_bounds, 0)
+
     if num_real_bounds == length(ul)
-        J3 = KBI
-        KAs0_bounds = KAs0
+        J3 .= KBI
+        KAs0_bounds .= KAs0
     else
-        J3          = (similar(Q, num_real_bounds * N, nu * N) .= 0)
-        KAs0_bounds = (similar(Q, num_real_bounds * N, 1) .= 0)
         for i in 1:N
             row_range   = (1 + (i - 1) * num_real_bounds):(i * num_real_bounds)
-            J3[row_range, :] = KBI[(1 + nu * (i - 1)):(nu * i), :][bool_vec_u, :]
-            KAs0_bounds[row_range, :]      = KAs0[(1 + nu * (i - 1)):(nu * i), 1][bool_vec_u,1]
+            J3[row_range, :] .= KBI[(1 + nu * (i - 1)):(nu * i), :][bool_vec_u, :]
+            KAs0_bounds[row_range, :]      .= KAs0[(1 + nu * (i - 1)):(nu * i), 1][bool_vec_u,1]
         end
 
         ul = ul[bool_vec_u]
         uu = uu[bool_vec_u]
     end
 
-    lcon2 = (similar(Q, size(J2, 1), 1) .= 0)
-    ucon2 = (similar(Q, size(J2, 1), 1) .= 0)
+    lcon2 = similar(Q, size(J2, 1), 1); fill!(lcon2, 0)
+    ucon2 = similar(Q, size(J2, 1), 1); fill!(ucon2, 0)
 
-    lcon3 = (similar(Q, size(J3, 1), 1) .= 0)
-    ucon3 = (similar(Q, size(J3, 1), 1) .= 0)
+    lcon3 = similar(Q, size(J3, 1), 1); fill!(lcon3, 0)
+    ucon3 = similar(Q, size(J3, 1), 1); fill!(ucon3, 0)
 
     for i in 1:N
         lcon2[((i - 1) * length(su) + 1):(i * length(su)),1] = sl
@@ -809,18 +816,19 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
     LinearAlgebra.axpy!(-1, KAs0_bounds, ucon3)
 
 
-    J = (similar(Q, (size(J1, 1) + size(J2, 1) + size(J3, 1)), size(J1, 2)) .= 0)
+    J = similar(Q, (size(J1, 1) + size(J2, 1) + size(J3, 1)), size(J1, 2)); fill!(J, 0)
     J[1:size(J1, 1), :] .= J1
 
     if size(J2, 1) > 0
         J[(size(J1, 1) + 1):(size(J1, 1) + size(J2, 1)), :] .= J2
     end
+
     if size(J3, 1) >0
         J[(size(J1, 1) + size(J2, 1) + 1):(size(J1, 1) + size(J2, 1) + size(J3, 1)), :] .= J3
     end
 
-    lcon = (similar(Q, size(J, 1)) .= 0)
-    ucon = (similar(Q, size(J, 1)) .= 0)
+    lcon = similar(Q, size(J, 1)); fill!(lcon, 0)
+    ucon = similar(Q, size(J, 1)); fill!(ucon, 0)
 
     lcon[1:length(lcon1)] .= lcon1
     ucon[1:length(ucon1)] .= ucon1
@@ -879,12 +887,12 @@ function _build_block_matrices(
     nu = size(R, 1)
 
     if K == nothing
-        K = (similar(Q, nu, ns) .= 0)
+        K = similar(Q, nu, ns); fill!(K, 0)
     end    
   
     # Define block matrices
-    block_B = (similar(Q, ns * (N + 1), nu * N) .= 0)
-    block_A = (similar(Q, ns * (N + 1), ns) .= 0)
+    block_B = similar(Q, ns * (N + 1), nu * N); fill!(block_B, 0)
+    block_A = similar(Q, ns * (N + 1), ns); fill!(block_A, 0)
     block_Q = SparseArrays.sparse([],[], eltype(Q)[], ns * (N + 1), ns * (N + 1))
     block_R = SparseArrays.sparse([],[], eltype(R)[], nu * N, nu * N)
     block_S = SparseArrays.sparse([],[], eltype(S)[], ns * (N + 1), nu * N)
@@ -895,10 +903,10 @@ function _build_block_matrices(
     nF1 = size(F, 1)
     nF2 = size(F, 2)
     
-    block_E  = (similar(Q, nE1 * N, nE2 * (N + 1)) .= 0)
-    block_F  = (similar(Q, nF1 * N, nF2 * N) .= 0)
-    block_gl = (similar(Q, nE1 * N, 1) .= 0)
-    block_gu = (similar(Q, nE1 * N, 1) .= 0)
+    block_E  = similar(Q, nE1 * N, nE2 * (N + 1)); fill!(block_E, 0)
+    block_F  = similar(Q, nF1 * N, nF2 * N); fill!(block_F, 0)
+    block_gl = similar(Q, nE1 * N, 1); fill!(block_gl, 0)
+    block_gu = similar(Q, nE1 * N, 1); fill!(block_gu, 0)
   
     # Build E, F, and d (gl and gu) blocks
     for i in 1:N
@@ -927,18 +935,20 @@ function _build_block_matrices(
         block_K[K_row_range, ((j - 1) * ns + 1):(j * ns)] = K
     end
 
-    block_A[1:ns, 1:ns] = Matrix(LinearAlgebra.I, ns, ns)
-  
+    for i in 1:ns
+        block_A[i, i] = 1.0
+    end
+
     A_k = copy(A)
-    BK  = (similar(Q, size(B, 1), size(K, 2)) .= 0)
+    BK  = similar(Q, size(B, 1), size(K, 2))
     LinearAlgebra.mul!(BK, B, K)
     LinearAlgebra.axpy!(1, BK, A_k)
 
     # Define matrices for mul!
     A_klast  = copy(A_k)
     A_knext  = copy(A_k)
-    AB_klast = (similar(Q, size(B, 1), size(B, 2)) .= 0)
-    AB_k     = (similar(Q, size(B, 1), size(B, 2)) .= 0)
+    AB_klast = similar(Q, size(B, 1), size(B, 2)); fill!(AB_klast, 0)
+    AB_k     = similar(Q, size(B, 1), size(B, 2)); fill!(AB_k, 0)
   
     # Fill the A and B matrices
     for i in 1:(N - 1)
@@ -986,11 +996,11 @@ function _build_block_matrices(
     )
 end
 
-function _build_H_blocks(block_Q, block_R, block_A, block_B, block_S, block_K, s0, N, K::MK) where MK <: Nothing
-    As0      = (similar(block_A, size(block_A, 1), 1) .= 0)
-    QB       = (similar(block_A, size(block_Q, 1), size(block_B, 2)) .= 0)
-    STB      = (similar(block_A, size(block_S, 2), size(block_B, 2)) .= 0)
-    B_Q_B    = (similar(block_A, size(block_B, 2), size(block_B, 2)) .= 0)
+function _build_H_blocks(block_Q, block_R, block_A::M, block_B::M, block_S, block_K, s0, N, K::MK) where {T, M <: AbstractMatrix{T}, MK <: Nothing}
+    As0      = similar(block_A, size(block_A, 1), 1)
+    QB       = similar(block_A, size(block_Q, 1), size(block_B, 2))
+    STB      = similar(block_A, size(block_S, 2), size(block_B, 2))
+    B_Q_B    = similar(block_A, size(block_B, 2), size(block_B, 2))
 
     LinearAlgebra.mul!(As0, block_A, s0)
     LinearAlgebra.mul!(QB, block_Q, block_B)
@@ -1003,32 +1013,32 @@ function _build_H_blocks(block_Q, block_R, block_A, block_B, block_S, block_K, s
     LinearAlgebra.axpy!(1, STB', B_Q_B)
 
     # Define linear term so that c = h
-    h = (similar(block_A, 1, size(block_B, 2)) .= 0)
+    h = similar(block_A, 1, size(block_B, 2))
     LinearAlgebra.axpy!(1, block_S, QB)
     LinearAlgebra.mul!(h, As0', QB)
 
     # Define linear term so that c0 = h0
-    h0   = (similar(block_A, 1,1) .= 0)
-    QAs0 = (similar(block_A, size(block_Q, 1), 1).= 0)
+    h0   = similar(block_A, 1,1)
+    QAs0 = similar(block_A, size(block_Q, 1), 1)
     LinearAlgebra.mul!(QAs0, block_Q, As0)
     LinearAlgebra.mul!(h0, As0', QAs0)
 
-    return (H = B_Q_B, c = h, c0 = h0 / 2)
+    return (H = B_Q_B, c = h, c0 = h0 ./ T(2))
 end
 
-function _build_H_blocks(block_Q, block_R, block_A, block_B, block_S, block_K, s0, N, K::MK) where MK <: AbstractMatrix
+function _build_H_blocks(block_Q, block_R, block_A, block_B, block_S, block_K, s0, N, K::MK) where {T, MK <: AbstractMatrix{T}}
 
-    As0      = (similar(block_A, size(block_A, 1), 1) .= 0)  
-    RK       = (similar(block_A, size(block_R, 1), size(block_K, 2)) .= 0)
-    RKB      = (similar(block_A, size(block_R, 1), size(block_B, 2)) .= 0)
-    SK       = (similar(block_A, size(block_S, 1), size(block_K, 2)) .= 0)
-    SKB      = (similar(block_A, size(block_S, 1), size(block_B, 2)) .= 0)
-    STB      = (similar(block_A, size(block_S, 2), size(block_B, 2)) .= 0)
-    KTSTB    = (similar(block_A, size(block_K, 2), size(block_B, 2)) .= 0)
-    KTRK     = (similar(block_A, size(block_K, 2), size(block_K, 2)) .= 0)
-    QB       = (similar(block_A, size(block_Q, 1), size(block_B, 2)) .= 0)
-    KTRK_B   = (similar(block_A, size(block_K, 2), size(block_B, 2)) .= 0)
-    B_Q_B    = (similar(block_A, size(block_B, 2), size(block_B, 2)) .= 0)
+    As0      = similar(block_A, size(block_A, 1), 1)
+    RK       = similar(block_A, size(block_R, 1), size(block_K, 2))
+    RKB      = similar(block_A, size(block_R, 1), size(block_B, 2))
+    SK       = similar(block_A, size(block_S, 1), size(block_K, 2))
+    SKB      = similar(block_A, size(block_S, 1), size(block_B, 2))
+    STB      = similar(block_A, size(block_S, 2), size(block_B, 2))
+    KTSTB    = similar(block_A, size(block_K, 2), size(block_B, 2))
+    KTRK     = similar(block_A, size(block_K, 2), size(block_K, 2))
+    QB       = similar(block_A, size(block_Q, 1), size(block_B, 2))
+    KTRK_B   = similar(block_A, size(block_K, 2), size(block_B, 2))
+    B_Q_B    = similar(block_A, size(block_B, 2), size(block_B, 2))
 
     LinearAlgebra.mul!(As0, block_A, s0)
     LinearAlgebra.mul!(RK, block_R, block_K)
@@ -1054,19 +1064,19 @@ function _build_H_blocks(block_Q, block_R, block_A, block_B, block_S, block_K, s
     LinearAlgebra.axpy!(1, STB', B_Q_B)
 
     # Define linear term so that c = h
-    h = (similar(block_A, 1, size(block_B, 2)) .= 0)
+    h = similar(block_A, 1, size(block_B, 2))
     LinearAlgebra.axpy!(1, block_S, QB)
     LinearAlgebra.axpy!(1, RK', QB)
     LinearAlgebra.mul!(h, As0', QB)
 
     # Define constant term sot hat c0 = h0
-    hR_term = (similar(block_A, 1, 1) .= 0) # = s0^T A^T K^T R K A s0
-    hS_term = (similar(block_A, 1, 1) .= 0) # = s0^T A^T K^T S^T A s0 = s0^T A^T S K A s0
-    hQ_term = (similar(block_A, 1, 1) .= 0) # = s0^T A^T Q A s0
+    hR_term = similar(block_A, 1, 1) # = s0^T A^T K^T R K A s0
+    hS_term = similar(block_A, 1, 1) # = s0^T A^T K^T S^T A s0 = s0^T A^T S K A s0
+    hQ_term = similar(block_A, 1, 1) # = s0^T A^T Q A s0
 
-    KTRKAs0 = (similar(block_A, size(block_K, 2), 1) .= 0)
-    SKAs0   = (similar(block_A, size(block_S, 1), 1) .= 0)
-    QAs0    = (similar(block_A, size(block_Q, 1), 1) .= 0)
+    KTRKAs0 = similar(block_A, size(block_K, 2), 1)
+    SKAs0   = similar(block_A, size(block_S, 1), 1)
+    QAs0    = similar(block_A, size(block_Q, 1), 1)
 
     LinearAlgebra.mul!(KTRKAs0, KTRK, As0)
     LinearAlgebra.mul!(SKAs0, SK, As0)
@@ -1076,7 +1086,7 @@ function _build_H_blocks(block_Q, block_R, block_A, block_B, block_S, block_K, s
     LinearAlgebra.mul!(hS_term, As0', SKAs0)
     LinearAlgebra.mul!(hQ_term, As0', QAs0)
     
-    h0 = hR_term/eltype(block_A)(2) + hQ_term/eltype(block_A)(2) + hS_term
+    h0 = hR_term ./ T(2) .+ hQ_term ./ T(2) .+ hS_term
 
     return (H = B_Q_B, c = h, c0 = h0)
 end
@@ -1085,19 +1095,22 @@ end
 
 function _build_G_blocks(block_A, block_B, block_E, block_F, block_K, block_gl, block_gu, s0, N)
   
-    G = (similar(block_A, size(block_F, 1), size(block_F, 2)) .= 0)
+    G = similar(block_A, size(block_F, 1), size(block_F, 2))
   
-    As0  = (similar(block_A, size(block_A, 1), 1) .= 0)
-    EAs0 = (similar(block_A, size(block_E, 1), 1) .= 0)
-    FK   = (similar(block_A, size(block_F, 1), size(block_K, 2)) .= 0)
+    As0  = similar(block_A, size(block_A, 1), 1)
+    EAs0 = similar(block_A, size(block_E, 1), 1)
+    FK   = similar(block_A, size(block_F, 1), size(block_K, 2))
+
+    block_E_mul = similar(block_E)
+    LinearAlgebra.copyto!(block_E_mul, block_E)
 
     LinearAlgebra.mul!(FK, block_F, block_K)
-    LinearAlgebra.axpy!(1, FK, block_E)
-    LinearAlgebra.mul!(G, block_E, block_B)
+    LinearAlgebra.axpy!(1, FK, block_E_mul)
+    LinearAlgebra.mul!(G, block_E_mul, block_B)
     LinearAlgebra.axpy!(1, block_F, G)
 
     LinearAlgebra.mul!(As0, block_A, s0)
-    LinearAlgebra.mul!(EAs0, block_E, As0)
+    LinearAlgebra.mul!(EAs0, block_E_mul, As0)
     LinearAlgebra.axpy!(-1, EAs0, block_gl)
     LinearAlgebra.axpy!(-1, EAs0, block_gu)
   
@@ -1329,8 +1342,6 @@ function NLPModels.hess_structure!(
     return rows, cols
 end
 
-
-
 function NLPModels.hess_coord!(
     qp::SparseLQDynamicModel{T, V, M1, M2, M3},
     x::AbstractVector{T},
@@ -1375,8 +1386,6 @@ NLPModels.hess_coord!(
     obj_weight::Real = one(eltype(x)),
 ) = NLPModels.hess_coord!(qp, x, vals, obj_weight = obj_weight)
 
-
-
 function NLPModels.jac_structure!(
     qp::SparseLQDynamicModel{T, V, M1, M2, M3},
     rows::AbstractVector{<:Integer},
@@ -1385,7 +1394,6 @@ function NLPModels.jac_structure!(
     fill_structure!(qp.data.A, rows, cols)
     return rows, cols
 end
-
 
 function NLPModels.jac_structure!(
     qp::DenseLQDynamicModel{T, V, M1, M2, M3},
@@ -1413,7 +1421,6 @@ function NLPModels.jac_coord!(
     return vals
 end
 
-
 function NLPModels.jac_coord!(
     qp::DenseLQDynamicModel{T, V, M1, M2, M3},
     x::AbstractVector,
@@ -1429,7 +1436,6 @@ function NLPModels.jac_coord!(
     end
     return vals
 end
-
 
 """ 
     _build_H(Q, R, N; Qf = []) -> H
@@ -1557,8 +1563,8 @@ function _build_sparse_J3(K, N, uu, ul)
 
     full_bool_vec = fill(true, nu * N)
 
-    lcon3 = (similar(K, nu * N) .= 0)
-    ucon3 = (similar(K, nu * N) .= 0)
+    lcon3 = similar(K, nu * N); fill!(lcon3, 0)
+    ucon3 = similar(K, nu * N); fill!(ucon3, 0)
 
     for i in 1:N
         row_range   = (nu * (i - 1) + 1):(nu * i)
@@ -1567,8 +1573,8 @@ function _build_sparse_J3(K, N, uu, ul)
         J3[row_range, K_col_range] = K
         J3[row_range, I_col_range] = I_mat
 
-        lcon3[row_range] = ul
-        ucon3[row_range] = uu
+        lcon3[row_range] .= ul
+        ucon3[row_range] .= uu
         full_bool_vec[row_range] = bool_vec
     end
 

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -658,7 +658,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         for i in 1:N
             row_range = (1 + (i - 1) * num_real_bounds):(i * num_real_bounds)
             J2[row_range, :] .= block_B[(1 + ns * i): (ns * (i + 1)), :][bool_vec, :]
-            As0_bounds[row_range] .= As0[(1 + ns * i):(ns * (i + 1)), :][bool_vec, :]
+            As0_bounds[row_range] .= As0[(1 + ns * i):(ns * (i + 1))][bool_vec]
         end
 
         sl = sl[bool_vec]
@@ -791,7 +791,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         for i in 1:N
             row_range = (1 + (i - 1) * num_real_bounds):(i * num_real_bounds)
             J2[row_range, :] .= block_B[(1 + ns * i): (ns * (i + 1)), :][bool_vec_s, :]
-            As0_bounds[row_range] .= As0[(1 + ns * i):(ns * (i + 1)), :][bool_vec_s, :]
+            As0_bounds[row_range] .= As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s]
         end
 
         sl = sl[bool_vec_s]

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -612,7 +612,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
     num_real_bounds = sum(bool_vec)
 
     J2         = similar(Q, num_real_bounds * N, nu * N); fill!(J2, 0)
-    As0_bounds = similar(Q, num_real_bounds * N, 1); fill!(As0_bounds, 0)
+    As0_bounds = similar(s0, num_real_bounds * N); fill!(As0_bounds, 0)
 
     if num_real_bounds == length(sl)
         J2        .= block_B[(1 + ns):end,:]
@@ -621,15 +621,15 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         for i in 1:N
             row_range = (1 + (i - 1) * num_real_bounds):(i * num_real_bounds)
             J2[row_range, :] .= block_B[(1 + ns * i): (ns * (i + 1)), :][bool_vec, :]
-            As0_bounds[row_range, :] .= As0[(1 + ns * i):(ns * (i + 1)), :][bool_vec, :]
+            As0_bounds[row_range] .= As0[(1 + ns * i):(ns * (i + 1)), :][bool_vec, :]
         end
 
         sl = sl[bool_vec]
         su = su[bool_vec]
     end
 
-    lcon2 = similar(Q, size(J2, 1), 1); fill!(lcon2, 0)
-    ucon2 = similar(Q, size(J2, 1), 1); fill!(ucon2, 0)
+    lcon2 = similar(s0, size(J2, 1)); fill!(lcon2, 0)
+    ucon2 = similar(s0, size(J2, 1)); fill!(ucon2, 0)
 
 
     for i in 1:N
@@ -795,11 +795,11 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         uu = uu[bool_vec_u]
     end
 
-    lcon2 = similar(Q, size(J2, 1), 1); fill!(lcon2, 0)
-    ucon2 = similar(Q, size(J2, 1), 1); fill!(ucon2, 0)
+    lcon2 = similar(s0, size(J2, 1)); fill!(lcon2, 0)
+    ucon2 = similar(s0, size(J2, 1)); fill!(ucon2, 0)
 
-    lcon3 = similar(Q, size(J3, 1), 1); fill!(lcon3, 0)
-    ucon3 = similar(Q, size(J3, 1), 1); fill!(ucon3, 0)
+    lcon3 = similar(s0, size(J3, 1)); fill!(lcon3, 0)
+    ucon3 = similar(s0, size(J3, 1)); fill!(ucon3, 0)
 
     for i in 1:N
         lcon2[((i - 1) * length(su) + 1):(i * length(su)),1] = sl

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -468,10 +468,14 @@ su = Test.GenericArray(su)
 ul = Test.GenericArray(ul)
 uu = Test.GenericArray(uu)
 
-@test LQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=true) isa DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, SparseMatrixCSC{Float32, Int64}, Nothing}
-@test LQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=true) isa DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}}
-@test LQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=false) isa SparseLQDynamicModel{Float32, GenericArray{Float32, 1}, SparseMatrixCSC{Float32, Int64}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}, Nothing}
-@test LQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=false) isa SparseLQDynamicModel{Float32, GenericArray{Float32, 1}, SparseMatrixCSC{Float32, Int64}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}, GenericArray{Float32, 2}}
+@test (LQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=true) isa 
+    DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, SparseMatrixCSC{Float32, Int64}, Nothing})
+@test (LQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=true) isa 
+    DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}})
+@test (LQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=false) isa 
+    SparseLQDynamicModel{Float32, GenericArray{Float32, 1}, SparseMatrixCSC{Float32, Int64}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}, Nothing})
+@test (LQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=false) isa 
+    SparseLQDynamicModel{Float32, GenericArray{Float32, 1}, SparseMatrixCSC{Float32, Int64}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}, GenericArray{Float32, 2}})
 
 
 # Test with CUDA Array type
@@ -508,25 +512,33 @@ if CUDA.has_cuda_gpu()
     slc = CuArray{Float64}(undef, size(sl))
     suc = CuArray{Float64}(undef, size(su))
 
-    copyto!(Ac, A)
-    copyto!(Bc, B)
-    copyto!(Qc, Q)
-    copyto!(Rc, R)
-    copyto!(s0c, s0)
-    copyto!(Kc, K)
-    copyto!(Sc, S)
-    copyto!(Ec, E)
-    copyto!(Fc, F)
-    copyto!(glc, gl)
-    copyto!(guc, gu)
-    copyto!(ulc, ul)
-    copyto!(uuc, uu)
-    copyto!(slc, sl)
-    copyto!(suc, su)
+    LinearAlgebra.copyto!(Ac, A)
+    LinearAlgebra.copyto!(Bc, B)
+    LinearAlgebra.copyto!(Qc, Q)
+    LinearAlgebra.copyto!(Rc, R)
+    LinearAlgebra.copyto!(s0c, s0)
+    LinearAlgebra.copyto!(Kc, K)
+    LinearAlgebra.copyto!(Sc, S)
+    LinearAlgebra.copyto!(Ec, E)
+    LinearAlgebra.copyto!(Fc, F)
+    LinearAlgebra.copyto!(glc, gl)
+    LinearAlgebra.copyto!(guc, gu)
+    LinearAlgebra.copyto!(ulc, ul)
+    LinearAlgebra.copyto!(uuc, uu)
+    LinearAlgebra.copyto!(slc, sl)
+    LinearAlgebra.copyto!(suc, su)
 
-    @test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10, dense=false) isa SparseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, Nothing}
-    @test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc,  dense=false) isa SparseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}
+    @test (LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10, dense=false) isa SparseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, 
+        SparseMatrixCSC{Float64, Int64}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, Nothing})
 
-    @test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10, dense=true) isa DenseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, Nothing}
-    @test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc,  dense=true) isa DenseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}
+    @test (LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc,  dense=false) isa
+        SparseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, SparseMatrixCSC{Float64, Int64}, 
+        CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}})
+
+    @test (LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10, dense=true) isa DenseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, 
+        CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, Nothing})
+        
+    @test (LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc,  dense=true) isa 
+        DenseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, 
+        CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}})
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra, SparseArrays, CUDA
+using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra, SparseArrays
 include("sparse_lq_test.jl")
 
 N  = 3 # number of time steps
@@ -445,58 +445,3 @@ R = randn(Float32,2,2)
 
 @test LQDynamicModel(s0,A,B,Q,R,10) isa SparseLQDynamicModel{Float32, Vector{Float32}, SparseArrays.SparseMatrixCSC{Float32, Int64}, SparseArrays.SparseMatrixCSC{Float32, Int64}, Matrix{Float32}}
 @test LQDynamicModel(s0,A,B,Q,R,10,dense=true) isa DenseLQDynamicModel{Float32, Vector{Float32}, Matrix{Float32}, Matrix{Float32}, Matrix{Float32}, SparseMatrixCSC{Float32, Int64}}
-
-# Test with CUDA Array type
-A = randn(2,2)
-B = randn(2,2)
-Q = randn(2,2)
-R = randn(2,2)
-K = randn(2,2)
-E = randn(2,2)
-F = randn(2,2)
-S = randn(2,2)
-gu = randn(2)
-gl = gu .- 2
-uu = randn(2)
-ul = uu .- 2
-su = randn(2)
-sl = su .- 2
-s0 = su .- 1
-
-s0c = CuArray{Float64}(undef, size(s0))
-Ac  = CuArray{Float64}(undef, size(A))
-Bc  = CuArray{Float64}(undef, size(B))
-Qc  = CuArray{Float64}(undef, size(Q))
-Rc  = CuArray{Float64}(undef, size(R))
-Kc  = CuArray{Float64}(undef, size(K))
-Sc   = CuArray{Float64}(undef, size(S))
-Ec  = CuArray{Float64}(undef, size(E))
-Fc  = CuArray{Float64}(undef, size(F))
-glc = CuArray{Float64}(undef, size(gl))
-guc = CuArray{Float64}(undef, size(gu))
-ulc = CuArray{Float64}(undef, size(ul))
-uuc = CuArray{Float64}(undef, size(uu))
-slc = CuArray{Float64}(undef, size(sl))
-suc = CuArray{Float64}(undef, size(su))
-
-copyto!(Ac, A)
-copyto!(Bc, B)
-copyto!(Qc, Q)
-copyto!(Rc, R)
-copyto!(s0c, s0)
-copyto!(Kc, K)
-copyto!(Sc, S)
-copyto!(Ec, E)
-copyto!(Fc, F)
-copyto!(glc, gl)
-copyto!(guc, gu)
-copyto!(ulc, ul)
-copyto!(uuc, uu)
-copyto!(slc, sl)
-copyto!(suc, su)
-
-@test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10, dense=false) isa SparseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, Nothing}
-@test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc,  dense=false) isa SparseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}
-
-@test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10, dense=true) isa DenseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, Nothing}
-@test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc,  dense=true) isa DenseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra, SparseArrays
+using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra, SparseArrays, CUDA
 include("sparse_lq_test.jl")
 
 N  = 3 # number of time steps
@@ -445,3 +445,58 @@ R = randn(Float32,2,2)
 
 @test LQDynamicModel(s0,A,B,Q,R,10) isa SparseLQDynamicModel{Float32, Vector{Float32}, SparseArrays.SparseMatrixCSC{Float32, Int64}, SparseArrays.SparseMatrixCSC{Float32, Int64}, Matrix{Float32}}
 @test LQDynamicModel(s0,A,B,Q,R,10,dense=true) isa DenseLQDynamicModel{Float32, Vector{Float32}, Matrix{Float32}, Matrix{Float32}, Matrix{Float32}, SparseMatrixCSC{Float32, Int64}}
+
+# Test with CUDA Array type
+A = randn(2,2)
+B = randn(2,2)
+Q = randn(2,2)
+R = randn(2,2)
+K = randn(2,2)
+E = randn(2,2)
+F = randn(2,2)
+S = randn(2,2)
+gu = randn(2)
+gl = gu .- 2
+uu = randn(2)
+ul = uu .- 2
+su = randn(2)
+sl = su .- 2
+s0 = su .- 1
+
+s0c = CuArray{Float64}(undef, size(s0))
+Ac  = CuArray{Float64}(undef, size(A))
+Bc  = CuArray{Float64}(undef, size(B))
+Qc  = CuArray{Float64}(undef, size(Q))
+Rc  = CuArray{Float64}(undef, size(R))
+Kc  = CuArray{Float64}(undef, size(K))
+Sc   = CuArray{Float64}(undef, size(S))
+Ec  = CuArray{Float64}(undef, size(E))
+Fc  = CuArray{Float64}(undef, size(F))
+glc = CuArray{Float64}(undef, size(gl))
+guc = CuArray{Float64}(undef, size(gu))
+ulc = CuArray{Float64}(undef, size(ul))
+uuc = CuArray{Float64}(undef, size(uu))
+slc = CuArray{Float64}(undef, size(sl))
+suc = CuArray{Float64}(undef, size(su))
+
+copyto!(Ac, A)
+copyto!(Bc, B)
+copyto!(Qc, Q)
+copyto!(Rc, R)
+copyto!(s0c, s0)
+copyto!(Kc, K)
+copyto!(Sc, S)
+copyto!(Ec, E)
+copyto!(Fc, F)
+copyto!(glc, gl)
+copyto!(guc, gu)
+copyto!(ulc, ul)
+copyto!(uuc, uu)
+copyto!(slc, sl)
+copyto!(suc, su)
+
+@test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10, dense=false) isa SparseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, Nothing}
+@test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc,  dense=false) isa SparseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}
+
+@test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10, dense=true) isa DenseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, Nothing}
+@test LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc,  dense=true) isa DenseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra, SparseArrays
+using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra, SparseArrays, CUDA
 include("sparse_lq_test.jl")
 
 N  = 3 # number of time steps

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra
+using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra, SparseArrays
 include("sparse_lq_test.jl")
 
 N  = 3 # number of time steps
@@ -433,3 +433,15 @@ set_gl!(lq_sparse, 2, rand_val)
 gltest[3] = rand_val
 set_gl!(lq_dense, 3, rand_val)
 @test get_gl(lq_dense) == gltest
+
+
+# Test non-default vector/matrix types
+s0 = randn(Float32,2)
+A = randn(Float32,2,2)
+B = randn(Float32,2,2)
+Q = randn(Float32,2,2)
+R = randn(Float32,2,2)
+
+
+@test LQDynamicModel(s0,A,B,Q,R,10) isa SparseLQDynamicModel{Float32, Vector{Float32}, SparseArrays.SparseMatrixCSC{Float32, Int64}, SparseArrays.SparseMatrixCSC{Float32, Int64}, Matrix{Float32}}
+@test LQDynamicModel(s0,A,B,Q,R,10,dense=true) isa DenseLQDynamicModel{Float32, Vector{Float32}, Matrix{Float32}, Matrix{Float32}, Matrix{Float32}, SparseMatrixCSC{Float32, Int64}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,11 +46,11 @@ K = rand(nu, ns)
 # Test with no bounds
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N)
 
 optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
@@ -71,11 +71,11 @@ solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
 # Test with lower bounds
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N;  sl = sl, ul=ul)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul)
 
 optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
@@ -96,11 +96,11 @@ solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
 # Test with upper bounds
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, su = su, uu = uu)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; su = su, uu = uu)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; su = su, uu = uu, dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; su = su, uu = uu, dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; su = su, uu = uu)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; su = su, uu = uu)
 
 optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
@@ -121,11 +121,11 @@ solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
 # Test with upper and lower bounds
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl=sl, ul=ul, su = su, uu = uu, dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; sl=sl, ul=ul, su = su, uu = uu, dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl=sl, ul=ul, su = su, uu = uu)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl=sl, ul=ul, su = su, uu = uu)
 
 optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
@@ -147,11 +147,11 @@ solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
 # Test with Qf matrix
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, Qf=Qf)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf, dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf, dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf)
 
 optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
@@ -182,11 +182,11 @@ u_values = value.(all_variables(model)[(1 + ns * (N + 1)):(ns * (N + 1) + nu * N
 # Test with E and F matrix bounds
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
 
 optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
@@ -206,11 +206,11 @@ solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
 # Test edge case where one state is unbounded, other(s) is bounded
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu, dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu, dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu)
 
 optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
@@ -232,11 +232,11 @@ solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
 # Test S matrix case
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S, dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S, dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
 
 optimize!(model)
 
@@ -258,11 +258,11 @@ solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
 # Test K matrix case without S
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K)
 
 optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
@@ -283,11 +283,11 @@ solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
 # Test K matrix case with S
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S, dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S, dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
 
 optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
@@ -334,11 +334,11 @@ K = rand(nu, ns)
 
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S, dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S, dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
 
 optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
@@ -360,11 +360,11 @@ solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
 # Test K with no bounds
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, E = E, F = F, gl = gl, gu = gu, K = K)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = LQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K, dense=false)
-lq_dense_from_data  = LQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K, dense=true)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K)
 
 optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
@@ -396,8 +396,8 @@ u_values = value.(all_variables(model)[(1 + ns * (N + 1)):(ns * (N + 1) + nu * N
 # Test get_* and set_* functions
 
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
-lq_sparse = LQDynamicModel(dnlp; dense=false)
-lq_dense  = LQDynamicModel(dnlp; dense=true)
+lq_sparse = SparseLQDynamicModel(dnlp)
+lq_dense  = DenseLQDynamicModel(dnlp)
 
 @test get_A(dnlp) == A
 @test get_A(lq_sparse) == A
@@ -468,13 +468,13 @@ su = Test.GenericArray(su)
 ul = Test.GenericArray(ul)
 uu = Test.GenericArray(uu)
 
-@test (LQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=true) isa 
+@test (DenseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 
     DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, SparseMatrixCSC{Float32, Int64}, Nothing})
-@test (LQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=true) isa 
+@test (DenseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 
     DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}})
-@test (LQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=false) isa 
+@test (SparseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 
     SparseLQDynamicModel{Float32, GenericArray{Float32, 1}, SparseMatrixCSC{Float32, Int64}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}, Nothing})
-@test (LQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su,  dense=false) isa 
+@test (SparseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 
     SparseLQDynamicModel{Float32, GenericArray{Float32, 1}, SparseMatrixCSC{Float32, Int64}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}, GenericArray{Float32, 2}})
 
 
@@ -528,17 +528,17 @@ if CUDA.has_cuda_gpu()
     LinearAlgebra.copyto!(slc, sl)
     LinearAlgebra.copyto!(suc, su)
 
-    @test (LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10, dense=false) isa SparseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, 
+    @test (SparseLQDynamicModel(s0c,Ac,Bc,Qc,Rc,10) isa SparseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, 
         SparseMatrixCSC{Float64, Int64}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, Nothing})
 
-    @test (LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc,  dense=false) isa
+    @test (SparseLQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc) isa
         SparseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, SparseMatrixCSC{Float64, Int64}, 
         CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}})
 
-    @test (LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10, dense=true) isa DenseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, 
+    @test (DenseLQDynamicModel(s0c,Ac,Bc,Qc,Rc,10) isa DenseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, 
         CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, Nothing})
         
-    @test (LQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc,  dense=true) isa 
+    @test (DenseLQDynamicModel(s0c,Ac,Bc,Qc,Rc,10; K = Kc, S = Sc, E = Ec, F = Fc, gl = glc, gu = guc, ul = ulc, uu = uuc, sl = slc, su = suc) isa 
         DenseLQDynamicModel{Float64, CuArray{Float64, 1, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, 
         CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}, SparseMatrixCSC{Float64, Int64}, CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}})
 end


### PR DESCRIPTION
Updated src code to handle non-default matrix types, mainly by removing `zeros` and using `similar` instead. Updated `runtests.jl` to test on `Float32` types and `CuArray` types. 

These changes also enable forming the dense formulation as `CuArray`s, so that the `H`, `J`, `lcon`, `ucon`, `lvar`, and `uvar` are returned as `CuArray`s when the original arrays passed to `LQDynamicModel` are `CuArray`s. 