### PR TITLE
Improved `DenseLQDynamicModel` construction to require less memory and build faster

### DIFF
--- a/examples/build_thinplate.jl
+++ b/examples/build_thinplate.jl
@@ -1,8 +1,10 @@
-function build_thinplate(ns, nu, N, dx, dt; d = fill(300.0, ns, N+1), Tbar = 300.0, dense::Bool = true, sl = -Inf, su = Inf)
+function build_thinplate(ns, nu, N, dx, dt; d = fill(300.0, ns, N+1), Tbar = 300.0, dense::Bool = true,
+    sl = -Inf, su = Inf, ul = -Inf, uu = Inf, K = nothing, S = zeros(ns, nu), E = zeros(0, ns), F = zeros(0, nu), gl = zeros(0), gu = zeros(0)
+    )
     Q = 1.0 * Matrix(LinearAlgebra.I, ns, ns)
     Qf= 1.0 * Matrix(LinearAlgebra.I, ns, ns)/dt
     R = 1.0 * Matrix(LinearAlgebra.I, nu, nu)/10
-
+ 
     kappa = 400. # thermal conductivity of copper, W/(m-K)
     rho = 8960. # density of copper, kg/m^3
     specificHeat = 386. # specific heat of copper, J/(kg-K)
@@ -11,9 +13,9 @@ function build_thinplate(ns, nu, N, dx, dt; d = fill(300.0, ns, N+1), Tbar = 300
     hCoeff = 1. # Convection coefficient, W/(m^2-K)
     Ta = 300. # The ambient temperature is assumed to be 300 degrees-Kelvin.
     emiss = .5 # emissivity of the plate surface
-
+ 
     conduction_constant =  1 / rho / specificHeat / thick / dx^2
-
+ 
     if ns == nu
         B = Matrix(LinearAlgebra.I, nu, nu) .* (- dt / (kappa * thick))
     elseif nu > ns
@@ -22,7 +24,7 @@ function build_thinplate(ns, nu, N, dx, dt; d = fill(300.0, ns, N+1), Tbar = 300
         # Space out the inputs, u, when nu < ns. These end up mostly evenly spaced
         u_floor   = floor(ns / nu)
         B = zeros(ns, nu)
-
+ 
         index   = 1
         for i in 1:ns
             if index <= nu && i >= index * u_floor
@@ -31,10 +33,10 @@ function build_thinplate(ns, nu, N, dx, dt; d = fill(300.0, ns, N+1), Tbar = 300
             end
         end
     end
-
-
+ 
+ 
     A = zeros(ns, ns)
-
+ 
     for i in 1:ns
         if i == 1
             A[1, 1] = (-dt * conduction_constant + 1) 
@@ -46,61 +48,82 @@ function build_thinplate(ns, nu, N, dx, dt; d = fill(300.0, ns, N+1), Tbar = 300
             A[i, i]     = (-2 * dt * conduction_constant + 1)
             A[i, i - 1] = (dt * conduction_constant)
             A[i, i + 1] = (dt * conduction_constant)
-
+ 
         end
     end
-
+ 
     s0 = fill(Tbar, ns)
     sl = fill(sl, ns)
     su = fill(su, ns)
-
-
+    ul = fill(ul, nu)
+    uu = fill(uu, nu)
+ 
+ 
     if dense
-        lqdm = DenseLQDynamicModel(s0, A, B, Q, R, N; Qf = Qf, sl = sl, su = su)
+        lqdm = DenseLQDynamicModel(s0, A, B, Q, R, N; Qf = Qf, sl = sl, su = su, ul = ul, uu = uu, E = E, F = F, K = K, S = S, gl = gl, gu = gu)
     else
-        lqdm = SparseLQDynamicModel(s0, A, B, Q, R, N; Qf = Qf, sl = sl, su = su)
+        lqdm = SparseLQDynamicModel(s0, A, B, Q, R, N; Qf = Qf, sl = sl, su = su, ul = ul, uu = uu, E = E, F = F, K = K, S = S, gl = gl, gu = gu)
     end
-
-    if dense
-        block_Q = lqdm.blocks.Q
-    else
-        block_Q = SparseArrays.sparse([],[],eltype(Q)[], ns * (N + 1), ns * (N + 1))
-        for i in 1:N
-            block_Q[(1 + (i - 1) * ns):(ns * i), (1 + (i - 1) * ns):(ns * i)] = Q
-        end
-        block_Q[(1 + ns * N):end, (1 + ns * N):end] = Qf
+ 
+ 
+    block_Q = SparseArrays.sparse([],[],eltype(Q)[], ns * (N + 1), ns * (N + 1))
+ 
+    for i in 1:N
+        block_Q[(1 + (i - 1) * ns):(ns * i), (1 + (i - 1) * ns):(ns * i)] = Q
     end
+ 
+    block_Q[(1 + ns * N):end, (1 + ns * N):end] = Qf
+ 
     
     
-    dvec = vec(d)
-    Qd  = similar(dvec)
-    dQd = zeros(1)
-    LinearAlgebra.mul!(Qd, block_Q, dvec)
-    LinearAlgebra.mul!(dQd, dvec', Qd)
+    Qd    = zeros(size(d, 1))
+    Qdvec = zeros(length(d))
+    dQd   = 0
+ 
+    for i in 1:N
+        LinearAlgebra.mul!(Qd, Q, d[:, i])
+        Qdvec[(1 + ns * (i - 1)):ns * i] = Qd
 
+        dQd += LinearAlgebra.dot(Qd, d[:, i])
+    end
+
+    LinearAlgebra.mul!(Qd, Qf, d[:, N + 1])
+    Qdvec[(1 + ns * N):end] = Qd
+
+    dQd += LinearAlgebra.dot(Qd, d[:, N + 1])
+
+ 
     # Add c and c0 that result from (x-d)^T Q (x-d) in the objective function
     if dense
         block_A = lqdm.blocks.A
         block_B = lqdm.blocks.B
-
+ 
         As0 = zeros(size(block_A, 1))
         LinearAlgebra.mul!(As0, block_A, s0)
-        dQB = zeros(size(block_B, 2))
-        LinearAlgebra.mul!(dQB, block_B', Qd)
-        dQAs0 = zeros(1)
-        LinearAlgebra.mul!(dQAs0, Qd', As0)
+        dQB = zeros(nu * N)
+        dQB_sub_block = zeros(nu)
 
-        lqdm.data.c0 += dQd[1,1] / 2
-        lqdm.data.c0 += -dQAs0[1,1]
+        for i in 1:N
+            B_sub_block = block_B[(1 + ns * (i - 1)):ns * i, :]
+            for j in N:-1:i
+                Qd_sub_block = Qdvec[(1 + ns * j):(ns * (j + 1))]
+                LinearAlgebra.mul!(dQB_sub_block, B_sub_block', Qd_sub_block)
 
+                dQB[(1 + nu * (j - i)):nu * (j - i + 1)] .+= dQB_sub_block
+            end
+        end
+
+
+        lqdm.data.c0 += dQd / 2
+        lqdm.data.c0 += -LinearAlgebra.dot(Qdvec, As0)
         lqdm.data.c  += - dQB
     else
         uvec = zeros(nu * N)
-        Qdvec = vcat(Qd, uvec)
-
-        lqdm.data.c0 += dQd[1,1] /2
-        lqdm.data.c  += - Qdvec
+        full_Qd = vcat(Qdvec, uvec)
+ 
+        lqdm.data.c0 += dQd / 2
+        lqdm.data.c  += - full_Qd
     end
-
+ 
     return lqdm
 end

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -615,19 +615,15 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
     if num_real_bounds == length(sl)
         As0_bounds .= As0[(1 + ns):ns * (N + 1)]
         for i in 1:N
-            B_row_range = 1:(ns *(N - i + 1))
-            B_sub_block = view(block_B, B_row_range, :)
-            J2[(1 + (i - 1) * ns):ns * N, (1 + nu * (i - 1)):(nu * i)] = B_sub_block
+            J2[(1 + (i - 1) * ns):ns * N, (1 + nu * (i - 1)):(nu * i)] = @view(block_B[1:(ns * (N - i + 1)),:])
         end
     else        
         for i in 1:N
             row_range = (1 + (i - 1) * num_real_bounds):(i * num_real_bounds)
-            As0_bounds[row_range] = As0[(1 + ns * i):(ns * (i + 1))][bool_vec]
+            As0_bounds[row_range] .= As0[(1 + ns * i):(ns * (i + 1))][bool_vec]
 
             for j in 1:(N - i + 1)
-                B_row_range = (1 + (j - 1) * ns):(j * ns)
-                B_sub_block = view(view(block_B, B_row_range, :), bool_vec, :)
-                J2[(1 + (i + j - 2) * num_real_bounds):((i + j - 1) * num_real_bounds), (1 + nu * (i - 1)):(nu * i)] .= B_sub_block
+                J2[(1 + (i + j - 2) * num_real_bounds):((i + j - 1) * num_real_bounds), (1 + nu * (i - 1)):(nu * i)] = @view(block_B[(1 + (j - 1) * ns):(j * ns), :][bool_vec, :])
             end
         end
 
@@ -754,9 +750,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
     if num_real_bounds == length(sl)
         As0_bounds .= As0[(1 + ns):ns * (N + 1)]
         for i in 1:N
-            B_row_range = 1:(ns *(N - i + 1))
-            B_sub_block = view(block_B, B_row_range, :)
-            J2[(1 + (i - 1) * ns):ns * N, (1 + nu * (i - 1)):(nu * i)] = B_sub_block
+            J2[(1 + (i - 1) * ns):ns * N, (1 + nu * (i - 1)):(nu * i)] = @view(block_B[1:(ns * (N - i + 1)),:])
         end
     else        
         for i in 1:N
@@ -764,9 +758,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
             As0_bounds[row_range] = As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s]
 
             for j in 1:(N - i + 1)
-                B_row_range = (1 + (j - 1) * ns):(j * ns)
-                B_sub_block = view(view(block_B, B_row_range, :), bool_vec_s, :)
-                J2[(1 + (i + j - 2) * num_real_bounds):((i + j - 1) * num_real_bounds), (1 + nu * (i - 1)):(nu * i)] .= B_sub_block
+                J2[(1 + (i + j - 2) * num_real_bounds):((i + j - 1) * num_real_bounds), (1 + nu * (i - 1)):(nu * i)] = @view(block_B[(1 + (j - 1) * ns):(j * ns), :][bool_vec_s, :])
             end
         end
 
@@ -806,11 +798,8 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
 
     if num_real_bounds == length(ul)
         KAs0_bounds .= KAs0
-
         for i in 1:N
-            KBI_row_range = 1:(nu * (N - i +1))
-            KBI_sub_block = view(KBI, KBI_row_range, :)
-            J3[(1 + (i - 1) * nu):nu * N, (1 + nu * (i - 1)):(nu * i)] = KBI_sub_block
+            J3[(1 + (i - 1) * nu):nu * N, (1 + nu * (i - 1)):(nu * i)] = @view(KBI[1:(nu * (N - i + 1)),:])
         end
     else
         for i in 1:N
@@ -818,9 +807,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
             KAs0_bounds[row_range] = KAs0[(1 + nu * (i - 1)):(nu * i)][bool_vec_u]
 
             for j in 1:(N - i +1)
-                KBI_row_range = (1 + (j - 1) * nu):(j * nu)
-                KBI_sub_block = view(view(KBI, KBI_row_range, :), bool_vec_u, :)
-                J3[(1 + (i + j - 2) * num_real_bounds):((i + j - 1) * num_real_bounds), (1 + nu * (i - 1)):(nu * i)] .= KBI_sub_block
+            J3[(1 + (i + j - 2) * num_real_bounds):((i + j - 1) * num_real_bounds), (1 + nu * (i - 1)):(nu * i)] = @view(KBI[(1 + (j - 1) * nu):(j * nu), :][bool_vec_u, :])
             end
         end
 

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -12,7 +12,7 @@ abstract type AbstractLQDynData{T,V} end
 """
     LQDynamicData{T,V,M,MK} <: AbstractLQDynData{T,V}
 
-A struct to represent the features of the optimization problem 
+A struct to represent the features of the optimization problem
 
 ```math
     minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
@@ -23,7 +23,7 @@ A struct to represent the features of the optimization problem
                 ul \\le u \\le uu
                 s_0 = s0
 ```
---- 
+---
 Attributes include:
 - `s0`: initial state of system
 - `A` : constraint matrix for system states
@@ -73,7 +73,7 @@ end
 
 """
     LQDynamicData(s0, A, B, Q, R, N; ...) -> LQDynamicData{T, V, M, MK}
-A constructor for building an object of type `LQDynamicData` for the optimization problem 
+A constructor for building an object of type `LQDynamicData` for the optimization problem
 ```math
     minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
     subject to  s_{i+1} = A s_i + B u_i  \\forall i=0, 1, ..., N - 1
@@ -114,7 +114,7 @@ function LQDynamicData(
     R::M,
     N;
 
-    Qf::M = Q, 
+    Qf::M = Q,
     S::M  = _init_similar(Q, size(Q, 1), size(R, 1), T),
     E::M  = _init_similar(Q, 0, length(s0), T),
     F::M  = _init_similar(Q, 0, size(R, 1), T),
@@ -128,7 +128,7 @@ function LQDynamicData(
     gu::V = (similar(s0, size(F, 1)) .= Inf)
     ) where {T,V <: AbstractVector{T}, M <: AbstractMatrix{T}, MK <: Union{Nothing, AbstractMatrix{T}}}
 
-    if size(Q, 1) != size(Q, 2) 
+    if size(Q, 1) != size(Q, 2)
         error("Q matrix is not square")
     end
     if size(R, 1) != size(R, 1)
@@ -163,7 +163,7 @@ function LQDynamicData(
     if size(E, 2) != size(Q, 1)
         error("Dimensions of E are not the same as number of states")
     end
-    if size(F, 2) != size(R, 1) 
+    if size(F, 2) != size(R, 1)
         error("Dimensions of F are not the same as the number of inputs")
     end
     if length(gl) != size(E, 1)
@@ -195,7 +195,7 @@ end
 
 abstract type AbstractDynamicModel{T,V} <: QuadraticModels.AbstractQuadraticModel{T, V} end
 
-struct SparseLQDynamicModel{T, V, M1, M2, M3, MK} <:  AbstractDynamicModel{T,V} 
+struct SparseLQDynamicModel{T, V, M1, M2, M3, MK} <:  AbstractDynamicModel{T,V}
   meta::NLPModels.NLPModelMeta{T, V}
   counters::NLPModels.Counters
   data::QuadraticModels.QPData{T, V, M1, M2}
@@ -214,7 +214,7 @@ struct DenseLQDynamicBlocks{T, M}
     B::M
 end
 
-struct DenseLQDynamicModel{T, V, M1, M2, M3, M4, MK} <:  AbstractDynamicModel{T,V} 
+struct DenseLQDynamicModel{T, V, M1, M2, M3, M4, MK} <:  AbstractDynamicModel{T,V}
     meta::NLPModels.NLPModelMeta{T, V}
     counters::NLPModels.Counters
     data::QuadraticModels.QPData{T, V, M1, M2}
@@ -226,26 +226,26 @@ end
     SparseLQDynamicModel(dnlp::LQDynamicData)    -> SparseLQDynamicModel
     SparseLQDynamicModel(s0, A, B, Q, R, N; ...) -> SparseLQDynamicModel
 A constructor for building a `SparseLQDynamicModel <: QuadraticModels.AbstractQuadraticModel`
-Input data is for the problem of the form 
+Input data is for the problem of the form
 ```math
     minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
     subject to  s_{i+1} = A s_i + B u_i  for i=0, 1, ..., N-1
                 u_i = Kx_i + v_i  \\forall i = 0, 1, ..., N - 1
-                gl \\le E s_i + F u_i \\le gu for i = 0, 1, ..., N-1            
+                gl \\le E s_i + F u_i \\le gu for i = 0, 1, ..., N-1
                 sl \\le s \\le su
                 ul \\le u \\le uu
                 s_0 = s0
 ```
 ---
 
-Data is converted to the form 
+Data is converted to the form
 
 ```math
-    minimize    \\frac{1}{2} z^T H z 
+    minimize    \\frac{1}{2} z^T H z
     subject to  lcon \\le Jz \\le ucon
                 lvar \\le z \\le uvar
 ```
-Resulting `H` and `J` matrices are stored as `QuadraticModels.QPData` within the `SparseLQDynamicModel` struct and 
+Resulting `H` and `J` matrices are stored as `QuadraticModels.QPData` within the `SparseLQDynamicModel` struct and
 variable and constraint limits are stored within `NLPModels.NLPModelMeta`
 
 If `K` is defined, then `u` variables are replaced by `v` variables, and `u` can be queried by `get_u` and `get_s` within `DynamicNLPModels.jl`
@@ -261,7 +261,7 @@ function SparseLQDynamicModel(
     Q::M,
     R::M,
     N;
-    Qf::M = Q, 
+    Qf::M = Q,
     S::M  = _init_similar(Q, size(Q, 1), size(R, 1), T),
     E::M  = _init_similar(Q, 0, length(s0), T),
     F::M  = _init_similar(Q, 0, size(R, 1), T),
@@ -270,15 +270,15 @@ function SparseLQDynamicModel(
     su::V = (similar(s0) .=  Inf),
     ul::V = (similar(s0, size(R, 1)) .= -Inf),
     uu::V = (similar(s0, size(R, 1)) .=  Inf),
-    gl::V = (similar(s0, size(E, 1)) .= -Inf), 
-    gu::V = (similar(s0, size(F, 1)) .= Inf) 
+    gl::V = (similar(s0, size(E, 1)) .= -Inf),
+    gu::V = (similar(s0, size(F, 1)) .= Inf)
 ) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}, MK <: Union{Nothing, AbstractMatrix{T}}}
 
     dnlp = LQDynamicData(
-        s0, A, B, Q, R, N; 
-        Qf = Qf, S = S, E = E, F = F, K = K, 
+        s0, A, B, Q, R, N;
+        Qf = Qf, S = S, E = E, F = F, K = K,
         sl = sl, su = su, ul = ul, uu = uu, gl = gl, gu = gu)
-    
+
     SparseLQDynamicModel(dnlp)
 end
 
@@ -287,22 +287,22 @@ end
     DenseLQDynamicModel(s0, A, B, Q, R, N; ...) -> DenseLQDynamicModel
 A constructor for building a `DenseLQDynamicModel <: QuadraticModels.AbstractQuadraticModel`
 
-Input data is for the problem of the form 
+Input data is for the problem of the form
 ```math
     minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
     subject to  s_{i+1} = A s_i + B u_i  for i=0, 1, ..., N-1
                 u_i = Kx_i + v_i  \\forall i = 0, 1, ..., N - 1
-                gl \\le E s_i + F u_i \\le gu for i = 0, 1, ..., N-1            
+                gl \\le E s_i + F u_i \\le gu for i = 0, 1, ..., N-1
                 sl \\le s \\le su
                 ul \\le u \\le uu
                 s_0 = s0
 ```
 ---
 
-Data is converted to the form 
+Data is converted to the form
 
 ```math
-    minimize    \\frac{1}{2} u^T H u + h^T u + h0 
+    minimize    \\frac{1}{2} u^T H u + h^T u + h0
     subject to  Jz \\le g
                 ul \\le u \\le uu
 ```
@@ -323,7 +323,7 @@ function DenseLQDynamicModel(
     Q::M,
     R::M,
     N;
-    Qf::M = Q, 
+    Qf::M = Q,
     S::M  = _init_similar(Q, size(Q, 1), size(R, 1), T),
     E::M  = _init_similar(Q, 0, length(s0), T),
     F::M  = _init_similar(Q, 0, size(R, 1), T),
@@ -332,15 +332,15 @@ function DenseLQDynamicModel(
     su::V = (similar(s0) .=  Inf),
     ul::V = (similar(s0, size(R, 1)) .= -Inf),
     uu::V = (similar(s0, size(R, 1)) .=  Inf),
-    gl::V = (similar(s0, size(E, 1)) .= -Inf), 
+    gl::V = (similar(s0, size(E, 1)) .= -Inf),
     gu::V = (similar(s0, size(F, 1)) .= Inf)
 ) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}, MK <: Union{Nothing, AbstractMatrix{T}}}
 
     dnlp = LQDynamicData(
-        s0, A, B, Q, R, N; 
-        Qf = Qf, S = S, E = E, F = F, K = K, 
+        s0, A, B, Q, R, N;
+        Qf = Qf, S = S, E = E, F = F, K = K,
         sl = sl, su = su, ul = ul, uu = uu, gl = gl, gu = gu)
-    
+
     DenseLQDynamicModel(dnlp)
 end
 
@@ -366,8 +366,6 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     gl = dnlp.gl
     gu = dnlp.gu
 
-
-
     H   = _build_H(Q, R, N; Qf = Qf, S = S)
     J1  = _build_sparse_J1(A, B, N)
     J2  = _build_sparse_J2(E, F, N)
@@ -376,10 +374,10 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
 
     c0  = zero(T)
 
-    
+
     nvar = ns * (N + 1) + nu * N
     c  = _init_similar(s0, nvar, T)
-    
+
     lvar  = _init_similar(s0, nvar, T)
     uvar  = _init_similar(s0, nvar, T)
 
@@ -405,13 +403,13 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
         lvar[((N + 1) * ns + (j - 1) * nu + 1):((N + 1) * ns + j * nu)] = ul
         uvar[((N + 1) * ns + (j - 1) * nu + 1):((N + 1) * ns + j * nu)] = uu
     end
-    
+
     SparseLQDynamicModel(
         NLPModels.NLPModelMeta(
         nvar,
         x0   = _init_similar(s0, nvar, T),
         lvar = lvar,
-        uvar = uvar, 
+        uvar = uvar,
         ncon = ncon,
         lcon = lcon,
         ucon = ucon,
@@ -422,7 +420,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
         ),
         NLPModels.Counters(),
         QuadraticModels.QPData(
-        c0, 
+        c0,
         c,
         H,
         J
@@ -485,7 +483,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     FK    = _init_similar(Q, size(F, 1), size(K, 2), T)
     LinearAlgebra.mul!(FK, F, K)
     LinearAlgebra.axpy!(1, FK, new_E)
-    
+
     # Get H and J matrices from new matrices
     H   = _build_H(new_Q, R, N; Qf = Qf, S = new_S)
     J1  = _build_sparse_J1(new_A, B, N)
@@ -497,7 +495,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
 
 
     nvar = ns * (N + 1) + nu * N
-    
+
     lvar  = similar(s0, nvar); fill!(lvar, -Inf)
     uvar  = similar(s0, nvar); fill!(uvar, Inf)
 
@@ -524,8 +522,6 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
         ucon[(1 + ns * N + N * length(gl)):end] = ucon3
     end
 
-
-
     c0 = zero(T)
     c  = _init_similar(s0, nvar, T)
 
@@ -534,7 +530,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
         nvar,
         x0   = _init_similar(s0, nvar, T),
         lvar = lvar,
-        uvar = uvar, 
+        uvar = uvar,
         ncon = ncon,
         lcon = lcon,
         ucon = ucon,
@@ -545,7 +541,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
         ),
         NLPModels.Counters(),
         QuadraticModels.QPData(
-        c0, 
+        c0,
         c,
         H,
         J
@@ -553,7 +549,6 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
         dnlp
     )
 end
-
 
 function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}, MK <: Nothing}
     s0 = dnlp.s0
@@ -598,7 +593,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
 
     dl = repeat(gl, N)
     du = repeat(gu, N)
-    
+
     _set_G_blocks!(G, dl, du, block_B, block_A, s0, E, F, K, N)
     _set_J1_dense!(J, G, N)
 
@@ -615,7 +610,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         for i in 1:N
             J[(offset_s + 1 + (i - 1) * ns):(offset_s + ns * N), (1 + nu * (i - 1)):(nu * i)] = @view(block_B[1:(ns * (N - i + 1)),:])
         end
-    else        
+    else
         for i in 1:N
             row_range = (1 + (i - 1) * num_real_bounds_s):(i * num_real_bounds_s)
             As0_bounds[row_range] .= As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s]
@@ -637,7 +632,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
 
     lcon = _init_similar(s0, length(dl) + length(lcon2), T)
     ucon = _init_similar(s0, length(du) + length(ucon2), T)
-    
+
     lcon[1:length(dl)] = dl
     ucon[1:length(du)] = du
 
@@ -660,7 +655,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         nvar,
         x0   = _init_similar(s0, nvar, T),
         lvar = lvar,
-        uvar = uvar, 
+        uvar = uvar,
         ncon = ncon,
         lcon = lcon,
         ucon = ucon,
@@ -671,7 +666,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         ),
         NLPModels.Counters(),
         QuadraticModels.QPData(
-        c0, 
+        c0,
         c,
         H,
         J
@@ -710,7 +705,6 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
     block_A  = dense_blocks.A
     block_B  = dense_blocks.B
 
-
     H_blocks = _build_H_blocks(Q, R, block_A, block_B, S, Qf, K, s0, N)
 
     H  = H_blocks.H
@@ -721,7 +715,6 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
 
     bool_vec_u       = (ul .!= -Inf .|| uu .!= Inf)
     num_real_bounds_u  = sum(bool_vec_u)
-
 
 
     G   = _init_similar(Q, nc * N, nu, T)
@@ -754,7 +747,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         for i in 1:N
             J[(offset_s + 1 + (i - 1) * ns):(offset_s + ns * N), (1 + nu * (i - 1)):(nu * i)] = @view(block_B[1:(ns * (N - i + 1)),:])
         end
-    else        
+    else
         for i in 1:N
             row_range = (1 + (i - 1) * num_real_bounds_s):(i * num_real_bounds_s)
             As0_bounds[row_range] = As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s]
@@ -777,7 +770,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
             B_sub_block = view(block_B, B_row_range, :)
             LinearAlgebra.mul!(KB, K, B_sub_block)
         end
-        
+
         KBI[(1 + nu * (i - 1)):(nu * i),:] = KB
         LinearAlgebra.mul!(KAs0_block, K, As0[(1 + ns * (i - 1)):ns * i])
         KAs0[(1 + nu * (i - 1)):nu * i] = KAs0_block
@@ -795,7 +788,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
             KAs0_bounds[row_range] = KAs0[(1 + nu * (i - 1)):(nu * i)][bool_vec_u]
 
             for j in 1:(N - i +1)
-            J[(offset_u + 1 + (i + j - 2) * num_real_bounds_u):(offset_u + (i + j - 1) * num_real_bounds_u), (1 + nu * (i - 1)):(nu * i)] = @view(KBI[(1 + (j - 1) * nu):(j * nu), :][bool_vec_u, :])
+                J[(offset_u + 1 + (i + j - 2) * num_real_bounds_u):(offset_u + (i + j - 1) * num_real_bounds_u), (1 + nu * (i - 1)):(nu * i)] = @view(KBI[(1 + (j - 1) * nu):(j * nu), :][bool_vec_u, :])
             end
         end
 
@@ -815,7 +808,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
     LinearAlgebra.axpy!(-1, KAs0_bounds, lcon3)
     LinearAlgebra.axpy!(-1, KAs0_bounds, ucon3)
 
-    
+
     lcon = _init_similar(s0, size(J, 1), T)
     ucon = _init_similar(s0, size(J, 1), T)
 
@@ -831,7 +824,6 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         lcon[(length(dl) + length(lcon2) + 1):(length(dl) + length(lcon2) + length(lcon3))] = lcon3
         ucon[(length(du) + length(ucon2) + 1):(length(du) + length(ucon2) + length(ucon3))] = ucon3
     end
-
 
     nvar = nu * N
     nnzj = size(J, 1) * size(J, 2)
@@ -856,7 +848,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         ),
         NLPModels.Counters(),
         QuadraticModels.QPData(
-        c0, 
+        c0,
         c,
         H,
         J
@@ -865,7 +857,6 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
         dense_blocks
     )
 end
-
 
 function _build_block_matrices(
     A::M, B::M, K, N
@@ -876,8 +867,8 @@ function _build_block_matrices(
 
     if K == nothing
         K = _init_similar(A, nu, ns, T)
-    end    
-  
+    end
+
     # Define block matrices
     block_A = _init_similar(A, ns * (N + 1), ns, T)
     block_B = _init_similar(B, ns * N, nu, T)
@@ -889,7 +880,7 @@ function _build_block_matrices(
     AB_klast = _init_similar(A, size(B, 1), size(B, 2), T)
     AB_k     = _init_similar(A, size(B, 1), size(B, 2), T)
 
-  
+
     block_B[1:ns, :] = B
 
     for i in 1:ns
@@ -907,18 +898,18 @@ function _build_block_matrices(
 
     block_B[(1 + ns):2 * ns, :] = AB_k
     AB_klast = copy(AB_k)
-  
+
     # Fill the A and B matrices
     for i in 2:(N - 1)
-        
+
         LinearAlgebra.mul!(AB_k, A_k, AB_klast)
-            
+
         LinearAlgebra.mul!(A_knext, A_k, A_klast)
 
         block_A[(ns * i + 1):ns * (i + 1),:] = A_knext
-  
+
         block_B[(1 + (i) * ns):((i + 1) * ns), :] = AB_k
-  
+
         AB_klast = copy(AB_k)
         A_klast  = copy(A_knext)
     end
@@ -928,7 +919,7 @@ function _build_block_matrices(
     block_A[(ns * N + 1):ns * (N + 1), :] = A_knext
 
     DenseLQDynamicBlocks{T, M}(
-        block_A, 
+        block_A,
         block_B
     )
 end
@@ -972,7 +963,6 @@ function _build_H_blocks(Q, R, block_A::M, block_B::M, S, Qf, K, s0, N) where {T
     As0S         = _init_similar(s0, nu, T)
     KTRKAs0      = _init_similar(s0, ns, T)
     SKAs0        = _init_similar(s0, ns, T)
-
 
     LinearAlgebra.mul!(SK, S, K)
     LinearAlgebra.mul!(RK, R, K)
@@ -1030,7 +1020,7 @@ function _build_H_blocks(Q, R, block_A::M, block_B::M, S, Qf, K, s0, N) where {T
 
     for i in 1:N
         fill!(QB_block_vec, T(0))
-        rows_QB           = 1:(ns * (N - i)) 
+        rows_QB           = 1:(ns * (N - i))
         rows_QfB          = (1 + ns * (N - i)):(ns * (N - i + 1))
 
         QB_block_vec[(1 + ns * i):(ns * N), :]     = quad_term_B[rows_QB, :]
@@ -1061,7 +1051,6 @@ function _build_H_blocks(Q, R, block_A::M, block_B::M, S, Qf, K, s0, N) where {T
 end
 
 
-
 function _set_G_blocks!(G, dl, du, block_B::M, block_A::M, s0, E, F, K::MK, N) where {T, M <: AbstractMatrix{T}, MK <: Nothing}
     ns = size(E, 2)
     nu = size(F, 2)
@@ -1074,7 +1063,7 @@ function _set_G_blocks!(G, dl, du, block_B::M, block_A::M, s0, E, F, K::MK, N) w
     EAs0 = _init_similar(s0, nc, T)
 
     LinearAlgebra.mul!(As0, block_A, s0)
-    
+
     for i in 1:N
         if i != N
             B_row_range = (1 + (i - 1) * ns):(i * ns)
@@ -1108,9 +1097,9 @@ function _set_G_blocks!(G, dl, du, block_B, block_A, s0, E, F, K::MK, N) where {
     LinearAlgebra.copyto!(E_FK, E)
     LinearAlgebra.mul!(FK, F, K)
     LinearAlgebra.axpy!(1.0, FK, E_FK)
-    
+
     LinearAlgebra.mul!(As0, block_A, s0)
-    
+
     for i in 1:N
         if i != N
             B_row_range = (1 + (i - 1) * ns):(i * ns)
@@ -1149,7 +1138,7 @@ Query the solution `u` from the solver. If `K = nothing`, the solution for `u` i
 If `K <: AbstractMatrix`, `solution_ref.solution` returns `v`, and `get_u` solves for `u` using the `K` matrix (and the `A` and `B` matrices if `lqdm <: DenseLQDynamicModel`)
 """
 function get_u(
-    solver_status, 
+    solver_status,
     lqdm::SparseLQDynamicModel{T, V, M1, M2, M3, MK}
     ) where {T, V <: AbstractVector{T}, M1 <: AbstractMatrix{T}, M2 <: AbstractMatrix{T}, M3 <: AbstractMatrix{T}, MK <: AbstractMatrix{T}}
 
@@ -1182,17 +1171,17 @@ function get_u(
 end
 
 function get_u(
-    solver_status, 
+    solver_status,
     lqdm::DenseLQDynamicModel{T, V, M1, M2, M3, M4, MK}
     ) where {T, V <: AbstractVector{T}, M1 <: AbstractMatrix{T}, M2 <: AbstractMatrix{T}, M3 <: AbstractMatrix{T}, M4 <: AbstractMatrix{T}, MK <: AbstractMatrix{T}}
 
     dnlp = lqdm.dynamic_data
-    
+
     N    = dnlp.N
     ns   = dnlp.ns
     nu   = dnlp.nu
     K    = dnlp.K
-    
+
     block_A = lqdm.blocks.A
     block_B = lqdm.blocks.B
 
@@ -1228,7 +1217,7 @@ function get_u(
 end
 
 function get_u(
-    solver_status, 
+    solver_status,
     lqdm::SparseLQDynamicModel{T, V, M1, M2, M3, MK}
     ) where {T, V <: AbstractVector{T}, M1 <: AbstractMatrix{T}, M2 <: AbstractMatrix{T}, M3 <: AbstractMatrix{T}, MK <: Nothing}
 
@@ -1242,7 +1231,7 @@ function get_u(
 end
 
 function get_u(
-    solver_status, 
+    solver_status,
     lqdm::DenseLQDynamicModel{T, V, M1, M2, M3, M4, MK}
     ) where {T, V <: AbstractVector{T}, M1 <: AbstractMatrix{T}, M2 <: AbstractMatrix{T}, M3 <: AbstractMatrix{T}, M4 <: AbstractMatrix{T}, MK <: Nothing}
 
@@ -1258,7 +1247,7 @@ If `lqdm <: DenseLQDynamicModel`, then `solution_ref.solution` returns `u` (if `
 transforming `u` or `v` into `s` using `A`, `B`, and `K` matrices.
 """
 function get_s(
-    solver_status, 
+    solver_status,
     lqdm::SparseLQDynamicModel{T, V, M1, M2, M3, MK}
     ) where {T, V <: AbstractVector{T}, M1 <: AbstractMatrix{T}, M2 <: AbstractMatrix{T}, M3 <: AbstractMatrix{T}, MK <: Union{Nothing, AbstractMatrix}}
 
@@ -1275,11 +1264,11 @@ function get_s(
     ) where {T, V <: AbstractVector{T}, M1 <: AbstractMatrix{T}, M2 <: AbstractMatrix{T}, M3 <: AbstractMatrix{T}, M4 <: AbstractMatrix{T}, MK <: Union{Nothing, AbstractMatrix}}
 
     dnlp = lqdm.dynamic_data
-    
+
     N    = dnlp.N
     ns   = dnlp.ns
     nu   = dnlp.nu
-    
+
     block_A = lqdm.blocks.A
     block_B = lqdm.blocks.B
 
@@ -1306,7 +1295,6 @@ function get_s(
 
     return s
 end
-
 
 for field in fieldnames(LQDynamicData)
     method = Symbol("get_", field)
@@ -1383,7 +1371,7 @@ function NLPModels.hess_structure!(
     return rows, cols
 end
 
-  
+
 function NLPModels.hess_structure!(
     qp::DenseLQDynamicModel{T, V, M1, M2, M3},
     rows::AbstractVector{<:Integer},
@@ -1495,20 +1483,18 @@ function NLPModels.jac_coord!(
     return vals
 end
 
-
-
-""" 
+"""
     _build_H(Q, R, N; Qf = []) -> H
 
-Build the (sparse) `H` matrix from square `Q` and `R` matrices such that 
- z^T H z = sum_{i=1}^{N-1} s_i^T Q s + sum_{i=1}^{N-1} u^T R u + s_N^T Qf s_n . 
+Build the (sparse) `H` matrix from square `Q` and `R` matrices such that
+ z^T H z = sum_{i=1}^{N-1} s_i^T Q s + sum_{i=1}^{N-1} u^T R u + s_N^T Qf s_n .
 
 
 # Examples
 ```julia-repl
 julia> Q = [1 2; 2 1]; R = ones(1,1); _build_H(Q, R, 2)
 6×6 SparseArrays.SparseMatrixCSC{Float64, Int64} with 9 stored entries:
- 1.0  2.0   ⋅    ⋅    ⋅    ⋅ 
+ 1.0  2.0   ⋅    ⋅    ⋅    ⋅
  2.0  1.0   ⋅    ⋅    ⋅    ⋅
   ⋅    ⋅   1.0  2.0   ⋅    ⋅
   ⋅    ⋅   2.0  1.0   ⋅    ⋅
@@ -1542,9 +1528,6 @@ function _build_H(
 
     return H
 end
-
-
-
 
 """
     _build_sparse_J1(A, B, N) -> J
@@ -1592,7 +1575,6 @@ function _build_sparse_J2(E, F, N)
     nc = size(E, 1)
 
     J2 = SparseArrays.sparse([],[], eltype(E)[], N * nc, ns * (N + 1) + nu * N)
-
 
     if nc != 0
         for i in 1:N

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -47,6 +47,8 @@ Attributes include:
 
 see also `LQDynamicData(s0, A, B, Q, R, N; ...)`
 """
+
+
 struct LQDynamicData{T, V, M, MK} <: AbstractLQDynData{T,V}
     s0::V
     A::M
@@ -115,9 +117,9 @@ function LQDynamicData(
     N;
 
     Qf::M = Q, 
-    S::M  = (similar(Q, size(Q, 1), size(R, 1)) .= 0),
-    E::M  = (similar(Q, 0, length(s0)) .= 0),
-    F::M  = (similar(Q, 0, size(R, 1)) .= 0),
+    S::M  = (similar(Q, size(Q, 1), size(R, 1)) .= 0.0),
+    E::M  = (similar(Q, 0, length(s0)) .= 0.0),
+    F::M  = (similar(Q, 0, size(R, 1)) .= 0.0),
     K::MK = nothing,
 
     sl::V = (similar(s0) .= -Inf),
@@ -292,9 +294,9 @@ function SparseLQDynamicModel(
     R::M,
     N;
     Qf::M = Q, 
-    S::M  = (similar(Q, size(Q, 1), size(R, 1)) .= 0),
-    E::M  = (similar(Q, 0, length(s0)) .= 0),
-    F::M  = (similar(Q, 0, size(R, 1)) .= 0),
+    S::M  = (similar(Q, size(Q, 1), size(R, 1)) .= 0.0),
+    E::M  = (similar(Q, 0, length(s0)) .= 0.0),
+    F::M  = (similar(Q, 0, size(R, 1)) .= 0.0),
     K::MK = nothing,
     sl::V = (similar(s0) .= -Inf),
     su::V = (similar(s0) .=  Inf),
@@ -354,9 +356,9 @@ function DenseLQDynamicModel(
     R::M,
     N;
     Qf::M = Q, 
-    S::M  = (similar(Q, size(Q, 1), size(R, 1)) .= 0),
-    E::M  = (similar(Q, 0, length(s0)) .= 0),
-    F::M  = (similar(Q, 0, size(R, 1)) .= 0),
+    S::M  = (similar(Q, size(Q, 1), size(R, 1)) .= 0.0),
+    E::M  = (similar(Q, 0, length(s0)) .= 0.0),
+    F::M  = (similar(Q, 0, size(R, 1)) .= 0.0),
     K::MK = nothing,
     sl::V = (similar(s0) .= -Inf),
     su::V = (similar(s0) .=  Inf),
@@ -881,7 +883,7 @@ function _build_dense_lq_dynamic_model(dnlp::LQDynamicData{T,V,M,MK}) where {T, 
 
     nvar = nu * N
     nnzj = size(J, 1) * size(J, 2)
-    nnzh = sum(LinearAlgebra.LowerTriangular(H) .!= 0)
+    nnzh = floor(Int, size(H, 1) * (size(H,1) + 1) / 2)
     ncon = size(J, 1)
 
     c = similar(s0, nvar)
@@ -915,19 +917,19 @@ end
 function _build_block_matrices(
     s0, Q, R, A, B, E, F, N, gu, gl, K;
     Qf = Q, 
-    S = (similar(Q, size(Q, 1), size(R, 1)) .= 0)
+    S = (similar(Q, size(Q, 1), size(R, 1)) .= 0.0)
     )
 
     ns = size(Q, 1)
     nu = size(R, 1)
 
     if K == nothing
-        K = similar(Q, nu, ns); fill!(K, 0)
+        K = similar(Q, nu, ns); fill!(K, 0.0)
     end    
   
     # Define block matrices
-    block_B = similar(Q, ns * (N + 1), nu * N); fill!(block_B, 0)
-    block_A = similar(Q, ns * (N + 1), ns); fill!(block_A, 0)
+    block_B = similar(Q, ns * (N + 1), nu * N); fill!(block_B, 0.0)
+    block_A = similar(Q, ns * (N + 1), ns); fill!(block_A, 0.0)
     block_Q = SparseArrays.sparse([],[], eltype(Q)[], ns * (N + 1), ns * (N + 1))
     block_R = SparseArrays.sparse([],[], eltype(R)[], nu * N, nu * N)
     block_S = SparseArrays.sparse([],[], eltype(S)[], ns * (N + 1), nu * N)
@@ -938,10 +940,10 @@ function _build_block_matrices(
     nF1 = size(F, 1)
     nF2 = size(F, 2)
     
-    block_E  = similar(Q, nE1 * N, nE2 * (N + 1)); fill!(block_E, 0)
-    block_F  = similar(Q, nF1 * N, nF2 * N); fill!(block_F, 0)
-    block_gl = similar(Q, nE1 * N, 1); fill!(block_gl, 0)
-    block_gu = similar(Q, nE1 * N, 1); fill!(block_gu, 0)
+    block_E  = similar(Q, nE1 * N, nE2 * (N + 1)); fill!(block_E, 0.0)
+    block_F  = similar(Q, nF1 * N, nF2 * N); fill!(block_F, 0.0)
+    block_gl = similar(Q, nE1 * N, 1); fill!(block_gl, 0.0)
+    block_gu = similar(Q, nE1 * N, 1); fill!(block_gu, 0.0)
   
     # Build E, F, and d (gl and gu) blocks
     for i in 1:N
@@ -982,14 +984,14 @@ function _build_block_matrices(
     # Define matrices for mul!
     A_klast  = copy(A_k)
     A_knext  = copy(A_k)
-    AB_klast = similar(Q, size(B, 1), size(B, 2)); fill!(AB_klast, 0)
-    AB_k     = similar(Q, size(B, 1), size(B, 2)); fill!(AB_k, 0)
+    AB_klast = similar(Q, size(B, 1), size(B, 2)); fill!(AB_klast, 0.0)
+    AB_k     = similar(Q, size(B, 1), size(B, 2)); fill!(AB_k, 0.0)
   
     # Fill the A and B matrices
     for i in 1:(N - 1)
         if i == 1
             block_A[(ns + 1):ns*2, :] = A_k
-            LinearAlgebra.mul!(AB_k, A_k, B)
+            LinearAlgebra.mul!(AB_k, A_k, B, 1, 0)
             for k in 1:(N-i)
                 row_range = (1 + (k + 1) * ns):((k + 2) * ns)
                 col_range = (1 + (k - 1) * nu):(k * nu)
@@ -1031,6 +1033,29 @@ function _build_block_matrices(
     )
 end
 
+function _build_H_blocks2(block_Q, block_R, block_A::M, block_B::M, block_S, block_K, s0, N, K::MK) where {T, M <: AbstractMatrix{T}, MK <: Nothing}
+
+    ns = size(block_B, 1) / (N + 1)
+    nu = size(block_B, 2) / N
+    Q = block_Q[1:ns, 1:ns]
+
+    H  = similar(block_A, size(block_B, 2), size(block_B, 2)); fill!(H, 0.0)
+    QB = similar(block_A, size(block_Q, 1), size(block_B, 2)); fill!(QB, 0.0)
+
+    for i in 1:N
+        AKB = block_B[(1 + i * ns):((i + 1) * ns), 1:nu] 
+        for j in 1:i
+
+        end
+    end
+
+end
+
+
+
+
+
+
 function _build_H_blocks(block_Q, block_R, block_A::M, block_B::M, block_S, block_K, s0, N, K::MK) where {T, M <: AbstractMatrix{T}, MK <: Nothing}
     As0      = similar(s0, size(block_A, 1))
     QB       = similar(block_A, size(block_Q, 1), size(block_B, 2))
@@ -1038,8 +1063,8 @@ function _build_H_blocks(block_Q, block_R, block_A::M, block_B::M, block_S, bloc
     B_Q_B    = similar(block_A, size(block_B, 2), size(block_B, 2))
 
     LinearAlgebra.mul!(As0, block_A, s0)
-    LinearAlgebra.mul!(QB, block_Q, block_B)
-    LinearAlgebra.mul!(STB, block_S', block_B)
+    LinearAlgebra.mul!(QB, block_Q, block_B, 1, 0)
+    LinearAlgebra.mul!(STB, block_S', block_B, 1, 0)
     LinearAlgebra.mul!(B_Q_B, block_B', QB)
 
     # Define Hessian term so that H = B_Q_B
@@ -1055,7 +1080,7 @@ function _build_H_blocks(block_Q, block_R, block_A::M, block_B::M, block_S, bloc
     # Define linear term so that c0 = h0
     h0   = similar(block_A, 1,1)
     QAs0 = similar(block_A, size(block_Q, 1), 1)
-    LinearAlgebra.mul!(QAs0, block_Q, As0)
+    LinearAlgebra.mul!(QAs0, block_Q, As0, 1, 0)
     LinearAlgebra.mul!(h0, As0', QAs0)
 
     return (H = B_Q_B, c = h, c0 = h0 ./ T(2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,8 +239,6 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, 
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
 
 optimize!(model)
-
-optimize!(model)
 solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
@@ -356,7 +354,6 @@ solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
 
 
 
-
 # Test K with no bounds
 model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, E = E, F = F, gl = gl, gu = gu, K = K)
 dnlp      = LQDynamicData(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K)
@@ -469,9 +466,9 @@ ul = Test.GenericArray(ul)
 uu = Test.GenericArray(uu)
 
 @test (DenseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 
-DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, SparseMatrixCSC{Float32, Int64}, Nothing})
+    DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, Nothing})
 @test (DenseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 
-DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}})
+DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}})
 @test (SparseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 
     SparseLQDynamicModel{Float32, GenericArray{Float32, 1}, SparseMatrixCSC{Float32, Int64}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}, Nothing})
 @test (SparseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 


### PR DESCRIPTION
Reformulated source code to build the Hessian and Jacobian a block at a time for the dense model. Previously, all block matrices were built, stored, and then multiplied together, but this was very inefficient as many of the multiplications were redundant. Instead, each block within the block matrices were multiplied together only when needed within for loops. 

This PR includes:
- redefining `DenseLQDynamicBlocks` to only save the `A` block and the `B` block. The latter block only contains the first column of the actual block `B` matrix, and it does not contain the first rows of zeros. This also removed any sparse matrices, which were inefficient within `LinearAlgebra.mul!`
- redefining `_build_block_matrices` to match `DenseLQDynamicBlocks`.
- redefining `_build_H_blocks` 
- redefining `_build_G_blocks`. 
- defining a new function, `_build_dense_J1` to form the Jacobian from the `G` blocks
- updating `build_dense_lq_dynamic_model` to be consistent with these changes
- updating `get_s` and `get_u` for working with the new block `B` matrix

This PR does not include updating the sparse formulation (which is also somewhat inefficient) or redefining the internal functions to be non-allocating. These changes are still needed but will be met with other PRs. 