### PR TITLE
Improved Efficiency of Sparse Model construction

### DIFF
--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -379,11 +379,11 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
 
     _set_sparse_H!(H_colptr, H_rowval, H_nzval, Q, R, N; Qf = Qf, S = S)
 
-    H = SparseMatrixCSC((N + 1) * ns + nu * N, (N + 1) * ns + nu * N, H_colptr, H_rowval, H_nzval)
+    H = SparseArrays.SparseMatrixCSC((N + 1) * ns + nu * N, (N + 1) * ns + nu * N, H_colptr, H_rowval, H_nzval)
 
     _set_sparse_J!(J_colptr, J_rowval, J_nzval, A, B, E, F, K, N)
 
-    J = SparseMatrixCSC((nc + ns) * N, (N + 1) * ns + nu * N, J_colptr, J_rowval, J_nzval)
+    J = SparseArrays.SparseMatrixCSC((nc + ns) * N, (N + 1) * ns + nu * N, J_colptr, J_rowval, J_nzval)
 
     SparseArrays.dropzeros!(H)
     SparseArrays.dropzeros!(J)
@@ -515,11 +515,11 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     # Get H and J matrices from new matrices
     _set_sparse_H!(H_colptr, H_rowval, H_nzval, new_Q, R, N; Qf = Qf, S = new_S)
 
-    H = SparseMatrixCSC((N + 1) * ns + nu * N, (N + 1) * ns + nu * N, H_colptr, H_rowval, H_nzval)
+    H = SparseArrays.SparseMatrixCSC((N + 1) * ns + nu * N, (N + 1) * ns + nu * N, H_colptr, H_rowval, H_nzval)
 
     _set_sparse_J!(J_colptr, J_rowval, J_nzval, new_A, B, new_E, F, K, bool_vec, N, num_real_bounds)
 
-    J = SparseMatrixCSC(ns * N + nc * N + num_real_bounds * N, (N + 1) * ns + nu * N, J_colptr, J_rowval, J_nzval)
+    J = SparseArrays.SparseMatrixCSC(ns * N + nc * N + num_real_bounds * N, (N + 1) * ns + nu * N, J_colptr, J_rowval, J_nzval)
 
     SparseArrays.dropzeros!(H)
     SparseArrays.dropzeros!(J)

--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -369,13 +369,13 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
 
     nc = size(E, 1)
 
-    H_colptr = _init_similar(Int[], ns * (N + 1) + nu * N + 1, Int)
-    H_rowval = _init_similar(Int[], (ns + nu) * N * ns + (ns + nu) * N * nu + ns * ns, Int)
-    H_nzval  = _init_similar(T[], (ns + nu) * N * ns + (ns + nu) * N * nu + ns * ns, T)
+    H_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
+    H_rowval = zeros(Int, (ns + nu) * N * ns + (ns + nu) * N * nu + ns * ns)
+    H_nzval  = zeros(T, (ns + nu) * N * ns + (ns + nu) * N * nu + ns * ns)
 
-    J_colptr = _init_similar(Int[], ns * (N + 1) + nu * N + 1, Int)
-    J_rowval = _init_similar(Int[], N * (ns^2 + ns * nu + ns) + N * (nc * ns + nc * nu), Int)
-    J_nzval  = _init_similar(T[],   N * (ns^2 + ns * nu + ns) + N * (nc * ns + nc * nu), T)
+    J_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
+    J_rowval = zeros(Int, N * (ns^2 + ns * nu + ns) + N * (nc * ns + nc * nu))
+    J_nzval  = zeros(T, N * (ns^2 + ns * nu + ns) + N * (nc * ns + nc * nu))
 
     _set_sparse_H!(H_colptr, H_rowval, H_nzval, Q, R, N; Qf = Qf, S = S)
 
@@ -484,13 +484,13 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     BK    = _init_similar(Q, size(B, 1), size(K, 2), T)
     FK    = _init_similar(Q, size(F, 1), size(K, 2), T)
 
-    H_colptr = _init_similar(Int[], ns * (N + 1) + nu * N + 1, Int)
-    H_rowval = _init_similar(Int[], (ns + nu) * N * ns + (ns + nu) * N * nu + ns * ns, Int)
-    H_nzval  = _init_similar(T[], (ns + nu) * N * ns + (ns + nu) * N * nu + ns * ns, T)
+    H_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
+    H_rowval = zeros(Int, (ns + nu) * N * ns + (ns + nu) * N * nu + ns * ns)
+    H_nzval  = zeros(T, (ns + nu) * N * ns + (ns + nu) * N * nu + ns * ns)
 
-    J_colptr = _init_similar(Int[], ns * (N + 1) + nu * N + 1, Int)
-    J_rowval = _init_similar(Int[], N * (ns^2 + ns * nu + ns) + N * (nc * ns + nc * nu) + N * (ns * num_real_bounds + num_real_bounds), Int)
-    J_nzval  = _init_similar(T[],   N * (ns^2 + ns * nu + ns) + N * (nc * ns + nc * nu) + N * (ns * num_real_bounds + num_real_bounds), T)
+    J_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
+    J_rowval = zeros(Int, N * (ns^2 + ns * nu + ns) + N * (nc * ns + nc * nu) + N * (ns * num_real_bounds + num_real_bounds))
+    J_nzval  = zeros(T, N * (ns^2 + ns * nu + ns) + N * (nc * ns + nc * nu) + N * (ns * num_real_bounds + num_real_bounds))
 
     LinearAlgebra.copyto!(new_Q, Q)
     LinearAlgebra.copyto!(new_S, S)
@@ -1537,7 +1537,8 @@ function _set_sparse_H!(
     H_colptr, H_rowval, H_nzval,
     Q::M, R::M, N;
     Qf::M = Q,
-    S::M = zeros(T, size(Q, 1), size(R, 1))) where {T, M <: AbstractMatrix{T}}
+    S::M = zeros(T, size(Q, 1), size(R, 1))
+) where {T, M <: AbstractMatrix{T}}
 
     ns = size(Q, 1)
     nu = size(R, 1)
@@ -1546,7 +1547,7 @@ function _set_sparse_H!(
     for i in 1:N
         for j in 1:ns
             H_nzval[(1 + (i - 1) * (ns^2 + nu * ns) + (j - 1) * (ns + nu)):(ns * j + nu * (j - 1) + (i - 1) * (ns^2 + nu * ns))]  = @view Q[:, j]
-            H_nzval[(1 + (i - 1) * (ns^2 + nu * ns) + j * ns + (j - 1) * nu):((i - 1) * (ns^2 + nu * ns) + j * (ns + nu))] = @view S'[:, j]
+            H_nzval[(1 + (i - 1) * (ns^2 + nu * ns) + j * ns + (j - 1) * nu):((i - 1) * (ns^2 + nu * ns) + j * (ns + nu))] = @view S[j, :]
             H_rowval[(1 + (i - 1) * (ns^2 + nu * ns) + (j - 1) * ns + (j - 1) * nu):(ns * j + nu * (j - 1) + (i - 1) * (ns^2 + nu * ns))] = (1 + (i - 1) * ns):ns * i
             H_rowval[(1 + (i - 1) * (ns^2 + nu * ns) + j * ns + (j - 1) * nu ):((i - 1) * (ns^2 + nu * ns) + j * (ns + nu))] =(1 + (N + 1) * ns + nu * (i - 1)):((N + 1) * ns + nu * i)
             H_colptr[((i - 1) * ns + j)] = 1 + (ns + nu) * (j - 1) + (i - 1) * (ns * nu + ns * ns)
@@ -1578,7 +1579,7 @@ end
     _set_sparse_J!(J_colptr, J_rowval, J_nzval, A, B, E, F, K, N)
 
 set the data needed to build a SparseArrays.SparseMatrixCSC matrix. J_colptr, J_rowval, and J_nzval
-are set so that they can be passed to SparseMatrixCSC() to obtain the Jacobain, `J`. The Jacobian
+are set so that they can be passed to SparseMatrixCSC() to obtain the Jacobian, `J`. The Jacobian
 contains the data for the following constraints:
 
 As_i + Bu_i = s_{i + 1}
@@ -1589,10 +1590,10 @@ ul <= Kx_i + v_i <= uu
 """
 function _set_sparse_J!(
     J_colptr, J_rowval, J_nzval,
-     A, B, E, F, K::MK, bool_vec,
-     N, nb
-     ) where {T, MK <: AbstractMatrix{T}}
-     # nb = num_real_bounds
+    A, B, E, F, K::MK, bool_vec,
+    N, nb
+) where {T, MK <: AbstractMatrix{T}}
+    # nb = num_real_bounds
 
     ns = size(A, 2)
     nu = size(B, 2)
@@ -1662,9 +1663,9 @@ end
 
 function _set_sparse_J!(
     J_colptr, J_rowval, J_nzval,
-     A::M, B::M, E, F, K::MK, N
-     ) where {T, M <: AbstractMatrix{T}, MK <: Nothing}
-     # nb = num_real_bounds
+    A::M, B::M, E, F, K::MK, N
+) where {T, M <: AbstractMatrix{T}, MK <: Nothing}
+    # nb = num_real_bounds
 
     ns = size(A, 2)
     nu = size(B, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,7 +53,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N)
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -78,7 +78,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul)
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -103,7 +103,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; su = su, uu = uu)
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; su = su, uu = uu)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -128,7 +128,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl=sl, ul=ul, su =
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl=sl, ul=ul, su = su, uu = uu)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -154,7 +154,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, 
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -189,7 +189,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, 
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -213,7 +213,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, 
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -239,7 +239,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, 
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -263,7 +263,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, 
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -288,7 +288,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, 
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -339,7 +339,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_w
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -364,7 +364,7 @@ lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl =
 lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K)
 
 optimize!(model)
-solution_ref_sparse           = madnlp(lq_sparse, max_iter=100) 
+solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
 solution_ref_dense            = madnlp(lq_dense, max_iter=100)
 solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
 solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
@@ -423,7 +423,7 @@ gltest[1] = rand_val
 set_gl!(dnlp, 1, rand_val)
 @test get_gl(dnlp) == gltest
 
-gltest[2] = rand_val 
+gltest[2] = rand_val
 set_gl!(lq_sparse, 2, rand_val)
 @test get_gl(lq_sparse) == gltest
 
@@ -465,11 +465,11 @@ su = Test.GenericArray(su)
 ul = Test.GenericArray(ul)
 uu = Test.GenericArray(uu)
 
-@test (DenseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 
+@test (DenseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa
     DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, Nothing})
-@test (DenseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 
+@test (DenseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa
 DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}})
-@test (SparseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 
+@test (SparseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa
     SparseLQDynamicModel{Float32, GenericArray{Float32, 1}, SparseMatrixCSC{Float32, Int64}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}, Nothing})
-@test (SparseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa 
+@test (SparseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa
     SparseLQDynamicModel{Float32, GenericArray{Float32, 1}, SparseMatrixCSC{Float32, Int64}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}, GenericArray{Float32, 2}})


### PR DESCRIPTION
The sparse model construction was very slow because of several for loops for building the sparse `H` and `J` matrices that contained setting sparse arrays with dense arrays (e.g., `H[..., ...] = Q`). This PR now builds the `H` and `J` matrices by instead building vectors for `colptr`, `rowval`, and `nzval` from the corresponding data, and then using the `SparseMatrixCSC` constructor to create the sparse array from these vectors. The `colptr`, `rowval`, and `nzval` for `H` and `J` are instantiated within the `_build_sparse_lq_dynamic_model` function. The `_set_sparse_H!` and `_set_sparse_J!` functions are then called to set this data. For large problems (N, ns, and nu ~100+), there is significant speedup from these changes.