### PR TITLE
Created function `add_jtsj!` and accompanying tests

### DIFF
--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -2194,6 +2194,17 @@ function Base.isreal(
     return isreal(Jac.Jac)
 end
 
+function Base.show(
+    Jac::LQJacobianOperator{T, V, M}
+) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}}
+    show(Jac.Jac)
+end
+
+function Base.display(
+    Jac::LQJacobianOperator{T, V, M}
+) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}}
+    display(Jac.Jac)
+end
 """
     LinearOperators.reset!(Jac::LQJacobianOperator{T, V, M})
 
@@ -2213,9 +2224,11 @@ end
 Generates `Jac' Σ Jac` and adds it to the matrix `H`.
 """
 function add_jtsj!(
-    H::AbstractMatrix{T},
+    H::M,
     Jac::LQJacobianOperator{T, V, M},
     Σ::V,
+    alpha::Number = 1,
+    beta::Number = 1
 ) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}}
 
     J   = Jac.Jac
@@ -2228,6 +2241,8 @@ function add_jtsj!(
     ΣJ1 = Jac.SJ1
     ΣJ2 = Jac.SJ2
     ΣJ3 = Jac.SJ3
+
+    LinearAlgebra.lmul!(beta, H)
 
     for i in 1:N
         J1_left_range = (1 + (i - 1) * nc):(i * nc)
@@ -2257,9 +2272,9 @@ function add_jtsj!(
                 row_range = (1 + nu * (k + (j - 1) - 1)):(nu * (k + (j - 1)))
                 col_range = (1 + nu * (k - 1)):(nu * k)
 
-                LinearAlgebra.mul!(view(H, row_range, col_range), left_block1', ΣJ1, 1, 1)
-                LinearAlgebra.mul!(view(H, row_range, col_range), left_block2', ΣJ2, 1, 1)
-                LinearAlgebra.mul!(view(H, row_range, col_range), left_block3', ΣJ3, 1, 1)
+                LinearAlgebra.mul!(view(H, row_range, col_range), left_block1', ΣJ1, alpha, 1)
+                LinearAlgebra.mul!(view(H, row_range, col_range), left_block2', ΣJ2, alpha, 1)
+                LinearAlgebra.mul!(view(H, row_range, col_range), left_block3', ΣJ3, alpha, 1)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ include("sparse_lq_test.jl")
 
 function tril_to_full!(dense::Matrix{T}) where T
     for i=1:size(dense,1)
-        Threads.@threads for j=i:size(dense,2)
+        for j=i:size(dense,2)
             @inbounds dense[i,j]=dense[j,i]
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -565,7 +565,7 @@ DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2},
 # Test LQJacobianOperator APIs
 lq_dense_imp = DenseLQDynamicModel(dnlp; implicit=true)
 
-@test length(get_jacobian(lq_dense_imp).Jac) == length(lq_dense_imp.data.A)
-@test size(get_jacobian(lq_dense_imp).Jac) == size(lq_dense_imp.data.A)
-@test isreal(get_jacobian(lq_dense_imp).Jac) == isreal(lq_dense_imp.data.A)
-@test eltype(get_jacobian(lq_dense_imp).Jac) == eltype(lq_dense_imp.data.A)
+@test length(get_jacobian(lq_dense_imp)) == length(lq_dense_imp.data.A)
+@test size(get_jacobian(lq_dense_imp)) == size(lq_dense_imp.data.A)
+@test isreal(get_jacobian(lq_dense_imp)) == isreal(lq_dense_imp.data.A)
+@test eltype(get_jacobian(lq_dense_imp)) == eltype(lq_dense_imp.data.A)


### PR DESCRIPTION
Added `add_jtsj!` to the source code to calculate $J^T \Sigma J$ from a `LQJacobianOperator` and a vector, $\Sigma$, and adds this value to a matrix $H$. The code is similar in construct to the `_build_H_blocks` function, but somewhat less efficient. This is because a new block matrix must be created and multiplied every iteration of the for loop, whereas `_build_H_blocks` could reuse the same matrix  several times (e.g., `_build_H_blocks` could calculate $QB$ one time and add it N times to $H$, whereas `add_jtsj!` must calculate separate $\Sigma_i B, \forall i = 1,...,N$).

Also updated `LQJacobianOperator` and removed the `Scaled_Jac` attribute (unnecessary) and changed the `J1B`, `J2B`, and `J3B` matrices to `SJ1`, `SJ2`, and `SJ3` for storing the scaled values of the Jacobian. Also added a function to `runtest.jl` to test `add_jtsj!` and a function to test the `mul` functions with the `LQJacobianOperator`. This latter function was just to simplify the file. 