### PR TITLE
Added support to efficiently build `SparseLQDynamicModel` from sparse `A, B, Q, R, K, S`

### DIFF
--- a/src/LinearQuadratic/sparse.jl
+++ b/src/LinearQuadratic/sparse.jl
@@ -338,14 +338,14 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
 
     nc = size(E, 1)
 
-    dropzeros!(A)
-    dropzeros!(B)
-    dropzeros!(Q)
-    dropzeros!(R)
-    dropzeros!(Qf)
-    dropzeros!(E)
-    dropzeros!(F)
-    dropzeros!(S)
+    SparseArrays.dropzeros!(A)
+    SparseArrays.dropzeros!(B)
+    SparseArrays.dropzeros!(Q)
+    SparseArrays.dropzeros!(R)
+    SparseArrays.dropzeros!(Qf)
+    SparseArrays.dropzeros!(E)
+    SparseArrays.dropzeros!(F)
+    SparseArrays.dropzeros!(S)
 
     H_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
     H_rowval = zeros(Int, length(Q.rowval) * N + length(R.rowval) * N + 2 * length(S.rowval) * N + length(Qf.rowval))
@@ -446,15 +446,15 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
 
     nc = size(E, 1)
 
-    dropzeros!(A)
-    dropzeros!(B)
-    dropzeros!(Q)
-    dropzeros!(R)
-    dropzeros!(Qf)
-    dropzeros!(E)
-    dropzeros!(F)
-    dropzeros!(S)
-    dropzeros!(K)
+    SparseArrays.dropzeros!(A)
+    SparseArrays.dropzeros!(B)
+    SparseArrays.dropzeros!(Q)
+    SparseArrays.dropzeros!(R)
+    SparseArrays.dropzeros!(Qf)
+    SparseArrays.dropzeros!(E)
+    SparseArrays.dropzeros!(F)
+    SparseArrays.dropzeros!(S)
+    SparseArrays.dropzeros!(K)
 
     bool_vec        = (ul .!= -Inf .|| uu .!= Inf)
     num_real_bounds = sum(bool_vec)
@@ -494,10 +494,10 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     LinearAlgebra.mul!(FK, F, K)
     LinearAlgebra.axpy!(1, FK, new_E)
 
-    dropzeros!(new_Q)
-    dropzeros!(new_A)
-    dropzeros!(new_E)
-    dropzeros!(new_S)
+    SparseArrays.dropzeros!(new_Q)
+    SparseArrays.dropzeros!(new_A)
+    SparseArrays.dropzeros!(new_E)
+    SparseArrays.dropzeros!(new_S)
 
     K_sparse = K[bool_vec, :]
 

--- a/src/LinearQuadratic/sparse.jl
+++ b/src/LinearQuadratic/sparse.jl
@@ -313,6 +313,259 @@ function _build_sparse_lq_dynamic_model(
     )
 end
 
+function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where {T, V <: AbstractVector{T}, M  <: SparseMatrixCSC{T}, MK <: Nothing}
+    s0 = dnlp.s0
+    A  = dnlp.A
+    B  = dnlp.B
+    Q  = dnlp.Q
+    R  = dnlp.R
+    N  = dnlp.N
+
+    Qf = dnlp.Qf
+    S  = dnlp.S
+    ns = dnlp.ns
+    nu = dnlp.nu
+    E  = dnlp.E
+    F  = dnlp.F
+    K  = dnlp.K
+
+    sl = dnlp.sl
+    su = dnlp.su
+    ul = dnlp.ul
+    uu = dnlp.uu
+    gl = dnlp.gl
+    gu = dnlp.gu
+
+    nc = size(E, 1)
+
+    H_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
+    H_rowval = zeros(Int, length(Q.rowval) * N + length(R.rowval) * N + 2 * length(S.rowval) * N + length(Qf.rowval))
+    H_nzval  = zeros(T, length(Q.nzval) * N + length(R.nzval) * N + 2 * length(S.nzval) * N + length(Qf.nzval))
+
+    J_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
+    J_rowval = zeros(Int, length(A.rowval) * N + length(B.rowval) * N + length(E.rowval) * N + length(F.rowval) * N + ns * N)
+    J_nzval  = zeros(T, length(A.nzval) * N + length(B.nzval) * N + length(E.nzval) * N + length(F.nzval) * N + ns * N)
+
+    _set_sparse_H!(H_colptr, H_rowval, H_nzval, Q, R, N; Qf = Qf, S = S)
+
+    H = SparseArrays.SparseMatrixCSC((N + 1) * ns + nu * N, (N + 1) * ns + nu * N, H_colptr, H_rowval, H_nzval)
+
+    _set_sparse_J!(J_colptr, J_rowval, J_nzval, A, B, E, F, K, N)
+
+    J = SparseArrays.SparseMatrixCSC((nc + ns) * N, (N + 1) * ns + nu * N, J_colptr, J_rowval, J_nzval)
+
+    SparseArrays.dropzeros!(H)
+    SparseArrays.dropzeros!(J)
+
+    c0  = zero(T)
+
+    nvar = ns * (N + 1) + nu * N
+    c  = _init_similar(s0, nvar, T)
+
+    lvar  = _init_similar(s0, nvar, T)
+    uvar  = _init_similar(s0, nvar, T)
+
+    lvar[1:ns] = s0
+    uvar[1:ns] = s0
+
+    lcon  = _init_similar(s0, ns * N + N * nc, T)
+    ucon  = _init_similar(s0, ns * N + N * nc, T)
+
+    ncon  = size(J, 1)
+    nnzj = length(J.rowval)
+    nnzh = length(H.rowval)
+
+    for i in 1:N
+        lvar[(i * ns + 1):((i + 1) * ns)] = sl
+        uvar[(i * ns + 1):((i + 1) * ns)] = su
+
+        lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
+        ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu
+    end
+
+    for j in 1:N
+        lvar[((N + 1) * ns + (j - 1) * nu + 1):((N + 1) * ns + j * nu)] = ul
+        uvar[((N + 1) * ns + (j - 1) * nu + 1):((N + 1) * ns + j * nu)] = uu
+    end
+
+    SparseLQDynamicModel(
+        NLPModels.NLPModelMeta(
+            nvar,
+            x0   = _init_similar(s0, nvar, T),
+            lvar = lvar,
+            uvar = uvar,
+            ncon = ncon,
+            lcon = lcon,
+            ucon = ucon,
+            nnzj = nnzj,
+            nnzh = nnzh,
+            lin = 1:ncon,
+            islp = (ncon == 0);
+        ),
+        NLPModels.Counters(),
+        QuadraticModels.QPData(
+            c0,
+            c,
+            H,
+            J
+        ),
+        dnlp
+    )
+
+end
+
+
+function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where {T, V <: AbstractVector{T}, M  <: SparseMatrixCSC{T}, MK <: SparseMatrixCSC{T}}
+    s0 = dnlp.s0
+    A  = dnlp.A
+    B  = dnlp.B
+    Q  = dnlp.Q
+    R  = dnlp.R
+    N  = dnlp.N
+
+    Qf = dnlp.Qf
+    S  = dnlp.S
+    ns = dnlp.ns
+    nu = dnlp.nu
+    E  = dnlp.E
+    F  = dnlp.F
+    K  = dnlp.K
+
+    sl = dnlp.sl
+    su = dnlp.su
+    ul = dnlp.ul
+    uu = dnlp.uu
+    gl = dnlp.gl
+    gu = dnlp.gu
+
+    nc = size(E, 1)
+
+    bool_vec        = (ul .!= -Inf .|| uu .!= Inf)
+    num_real_bounds = sum(bool_vec)
+
+    # Transform u variables to v variables
+    new_Q = _init_similar(Q, size(Q, 1), size(Q, 2), T)
+    new_S = _init_similar(S, size(S, 1), size(S, 2), T)
+    new_A = _init_similar(A, size(A, 1), size(A, 2), T)
+    new_E = _init_similar(E, size(E, 1), size(E, 2), T)
+    KTR   = _init_similar(Q, size(K, 2), size(R, 2), T)
+    SK    = _init_similar(Q, size(S, 1), size(K, 2), T)
+    KTRK  = _init_similar(Q, size(K, 2), size(K, 2), T)
+    BK    = _init_similar(Q, size(B, 1), size(K, 2), T)
+    FK    = _init_similar(Q, size(F, 1), size(K, 2), T)
+
+    H_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
+    H_rowval = zeros(Int, length(Q.rowval) * N + length(R.rowval) * N + 2 * length(S.rowval) * N + length(Qf.rowval))
+    H_nzval  = zeros(T, length(Q.nzval) * N + length(R.nzval) * N + 2 * length(S.nzval) * N + length(Qf.nzval))
+
+    LinearAlgebra.copyto!(new_Q, Q)
+    LinearAlgebra.copyto!(new_S, S)
+    LinearAlgebra.copyto!(new_A, A)
+    LinearAlgebra.copyto!(new_E, E)
+
+    LinearAlgebra.mul!(KTR, K', R)
+    LinearAlgebra.axpy!(1, KTR, new_S)
+
+    LinearAlgebra.mul!(SK, S, K)
+    LinearAlgebra.mul!(KTRK, KTR, K)
+    LinearAlgebra.axpy!(1, SK, new_Q)
+    LinearAlgebra.axpy!(1, SK', new_Q)
+    LinearAlgebra.axpy!(1, KTRK, new_Q)
+
+    LinearAlgebra.mul!(BK, B, K)
+    LinearAlgebra.axpy!(1, BK, new_A)
+
+    LinearAlgebra.mul!(FK, F, K)
+    LinearAlgebra.axpy!(1, FK, new_E)
+
+    K_sparse = K[bool_vec, :]
+
+    H_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
+    H_rowval = zeros(Int, length(Q.rowval) * N + length(R.rowval) * N + 2 * length(new_S.rowval) * N + length(Qf.rowval))
+    H_nzval  = zeros(T, length(Q.nzval) * N + length(R.nzval) * N + 2 * length(new_S.nzval) * N + length(Qf.nzval))
+
+
+    J_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
+    J_rowval = zeros(Int, length(new_A.rowval) * N + length(B.rowval) * N + length(new_E.rowval) * N + length(F.rowval) * N + ns * N + length(K_sparse.rowval) * N + num_real_bounds * N)
+    J_nzval  = zeros(T, length(new_A.nzval) * N + length(B.nzval) * N + length(new_E.nzval) * N + length(F.nzval) * N + ns * N + length(K_sparse.nzval) * N + num_real_bounds * N)
+
+    # Get H and J matrices from new matrices
+    _set_sparse_H!(H_colptr, H_rowval, H_nzval, new_Q, R, N; Qf = Qf, S = new_S)
+
+    H = SparseArrays.SparseMatrixCSC((N + 1) * ns + nu * N, (N + 1) * ns + nu * N, H_colptr, H_rowval, H_nzval)
+
+    _set_sparse_J!(J_colptr, J_rowval, J_nzval, new_A, B, new_E, F, K, bool_vec, N, num_real_bounds)
+
+    J = SparseArrays.SparseMatrixCSC(ns * N + nc * N + num_real_bounds * N, (N + 1) * ns + nu * N, J_colptr, J_rowval, J_nzval)
+
+    SparseArrays.dropzeros!(H)
+    SparseArrays.dropzeros!(J)
+
+    # Remove algebraic constraints if u variable is unbounded on both upper and lower ends
+    lcon3 = _init_similar(ul, nu * N, T)
+    ucon3 = _init_similar(ul, nu * N, T)
+
+    ul = ul[bool_vec]
+    uu = uu[bool_vec]
+
+    lcon3 = repeat(ul, N)
+    ucon3 = repeat(uu, N)
+
+    nvar = ns * (N + 1) + nu * N
+
+    lvar  = similar(s0, nvar); fill!(lvar, -Inf)
+    uvar  = similar(s0, nvar); fill!(uvar, Inf)
+
+    lvar[1:ns] = s0
+    uvar[1:ns] = s0
+
+    lcon  = _init_similar(s0, ns * N + N * length(gl) + length(lcon3))
+    ucon  = _init_similar(s0, ns * N + N * length(gl) + length(lcon3))
+
+    ncon  = size(J, 1)
+    nnzj = length(J.rowval)
+    nnzh = length(H.rowval)
+
+    for i in 1:N
+        lvar[(i * ns + 1):((i + 1) * ns)] = sl
+        uvar[(i * ns + 1):((i + 1) * ns)] = su
+
+        lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
+        ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu
+    end
+
+    if length(lcon3) > 0
+        lcon[(1 + ns * N + N * nc):(ns * N + nc * N + num_real_bounds * N)] = lcon3
+        ucon[(1 + ns * N + N * nc):(ns * N + nc * N + num_real_bounds * N)] = ucon3
+    end
+
+    c0 = zero(T)
+    c  = _init_similar(s0, nvar, T)
+
+    SparseLQDynamicModel(
+        NLPModels.NLPModelMeta(
+            nvar,
+            x0   = _init_similar(s0, nvar, T),
+            lvar = lvar,
+            uvar = uvar,
+            ncon = ncon,
+            lcon = lcon,
+            ucon = ucon,
+            nnzj = nnzj,
+            nnzh = nnzh,
+            lin = 1:ncon,
+            islp = (ncon == 0);
+        ),
+        NLPModels.Counters(),
+        QuadraticModels.QPData(
+            c0,
+            c,
+            H,
+            J
+        ),
+        dnlp
+    )
+end
 
 """
     _set_sparse_H!(H_colptr, H_rowval, H_nzval, Q, R, N; Qf = Q, S = zeros(T, size(Q, 1), size(R, 1))
@@ -360,6 +613,58 @@ function _set_sparse_H!(
     end
 
     H_colptr[ns * (N + 1) + nu * N + 1] = length(H_nzval) + 1
+end
+
+function _set_sparse_H!(
+    H_colptr, H_rowval, H_nzval,
+    Q::M, R::M, N;
+    Qf::M = Q,
+    S::M = spzeros(T, size(Q, 1), size(R, 1))
+) where {T, M <: SparseMatrixCSC{T}}
+
+    ST = SparseArrays.sparse(S')
+    ns = size(Q, 1)
+    nu = size(R, 1)
+
+    H_colptr[1] = 1
+
+    for i in 1:N
+        for j in 1:ns
+            Q_offset = length(Q.colptr[j]:(Q.colptr[j + 1] - 1))
+
+            H_nzval[(H_colptr[ns * (i - 1) + j]):(H_colptr[ns * (i - 1) + j] + Q_offset - 1)]  = Q.nzval[Q.colptr[j]:(Q.colptr[j + 1] - 1)]
+            H_rowval[(H_colptr[ns * (i - 1) + j]):(H_colptr[ns * (i - 1) + j] + Q_offset - 1)] = Q.rowval[Q.colptr[j]:(Q.colptr[j + 1] - 1)] .+ ns * (i - 1)
+
+            ST_offset = length(ST.colptr[j]:(ST.colptr[j + 1] - 1))
+            H_nzval[(H_colptr[ns * (i - 1) + j] + Q_offset):(H_colptr[ns * (i - 1) + j] + Q_offset + ST_offset - 1)]  = ST.nzval[ST.colptr[j]:(ST.colptr[j + 1] - 1)]
+            H_rowval[(H_colptr[ns * (i - 1) + j] + Q_offset):(H_colptr[ns * (i - 1) + j] + Q_offset + ST_offset - 1)] = ST.rowval[ST.colptr[j]:(ST.colptr[j + 1] - 1)] .+ (nu * (i - 1) + ns * (N + 1))
+
+            H_colptr[ns * (i - 1) + j + 1] = H_colptr[ns * (i - 1) + j] + Q_offset + ST_offset
+        end
+    end
+
+    for j in 1:ns
+        Qf_offset = length(Qf.colptr[j]:(Qf.colptr[j + 1] - 1))
+        H_nzval[(H_colptr[N * ns + j]):(H_colptr[N * ns + j] + Qf_offset - 1)]  = Qf.nzval[Qf.colptr[j]:(Qf.colptr[j + 1] - 1)]
+        H_rowval[(H_colptr[N * ns + j]):(H_colptr[N * ns + j] + Qf_offset - 1)] = Qf.rowval[Qf.colptr[j]:(Qf.colptr[j + 1] - 1)] .+ (ns * N)
+        H_colptr[ns * N + j + 1] = H_colptr[ns * N + j] + Qf_offset
+    end
+
+    for i in 1:N
+        for j in 1:nu
+            S_offset = length(S.colptr[j]:(S.colptr[j + 1] - 1))
+
+            H_nzval[(H_colptr[ns * (N + 1) + nu * (i - 1) + j]):(H_colptr[ns * (N + 1) + nu * (i - 1) + j] + S_offset - 1)]  = S.nzval[S.colptr[j]:(S.colptr[j + 1] - 1)]
+            H_rowval[(H_colptr[ns * (N + 1) + nu * (i - 1) + j]):(H_colptr[ns * (N + 1) + nu * (i - 1) + j] + S_offset - 1)] = S.rowval[S.colptr[j]:(S.colptr[j + 1] - 1)] .+ ((i - 1) * ns)
+
+            R_offset = length(R.colptr[j]:(R.colptr[j + 1] - 1))
+
+            H_nzval[(H_colptr[ns * (N + 1) + nu * (i - 1) + j] + S_offset):(H_colptr[ns * (N + 1) + nu * (i - 1) + j] + S_offset + R_offset - 1)]  = R.nzval[R.colptr[j]:(R.colptr[j + 1] - 1)]
+            H_rowval[(H_colptr[ns * (N + 1) + nu * (i - 1) + j] + S_offset):(H_colptr[ns * (N + 1) + nu * (i - 1) + j] + S_offset + R_offset - 1)] = R.rowval[R.colptr[j]:(R.colptr[j + 1] - 1)] .+ ((i - 1) * nu + ns * (N + 1))
+
+            H_colptr[ns * (N + 1) + nu * (i - 1) + j + 1] = H_colptr[ns * (N + 1) + nu * (i - 1) + j] + S_offset + R_offset
+        end
+    end
 end
 
 """
@@ -503,4 +808,182 @@ function _set_sparse_J!(
     end
 
     J_colptr[ns * (N + 1) + nu * N + 1] = length(J_nzval) + 1
+end
+
+function _set_sparse_J!(
+    J_colptr, J_rowval, J_nzval,
+    A::M, B::M, E::M, F::M, K::MK, bool_vec,
+    N, nb
+) where {T, M <: SparseMatrixCSC{T}, MK <: SparseMatrixCSC{T}}
+
+    ns = size(A, 2)
+    nu = size(B, 2)
+    nc = size(E, 1)
+
+    I_mat = _init_similar(K, nu, nu)
+
+    I_mat[LinearAlgebra.diagind(I_mat)] .= T(1)
+
+    KI       = I_mat[bool_vec, :]
+    K_sparse = K[bool_vec, :]
+
+    J_colptr[1] = 1
+
+    # Set the first block column of A, E, and K
+    for j in 1:ns
+        A_offset = length(A.colptr[j]:(A.colptr[j + 1] - 1))
+        J_nzval[(J_colptr[j]):(J_colptr[j] + A_offset - 1)]  = A.nzval[A.colptr[j]:(A.colptr[j + 1] - 1)]
+        J_rowval[(J_colptr[j]):(J_colptr[j] + A_offset - 1)] = A.rowval[A.colptr[j]:(A.colptr[j + 1] - 1)]
+
+        E_offset = length(E.colptr[j]:(E.colptr[j + 1] - 1))
+
+        J_nzval[(J_colptr[j] + A_offset):(J_colptr[j] + A_offset + E_offset - 1)]  = E.nzval[E.colptr[j]:(E.colptr[j + 1] - 1)]
+        J_rowval[(J_colptr[j] + A_offset):(J_colptr[j] + A_offset + E_offset - 1)] = E.rowval[E.colptr[j]:(E.colptr[j + 1] - 1)] .+ (ns * N)
+
+        K_offset = length(K_sparse.colptr[j]:(K_sparse.colptr[j + 1] - 1))
+
+        (J_nzval[(J_colptr[j] + A_offset + E_offset):(J_colptr[j] + A_offset + E_offset + K_offset - 1)]
+            = K_sparse.nzval[K_sparse.colptr[j]:(K_sparse.colptr[j + 1] - 1)])
+        (J_rowval[(J_colptr[j] + A_offset + E_offset):(J_colptr[j] + A_offset + E_offset + K_offset - 1)]
+            = K_sparse.rowval[K_sparse.colptr[j]:(K_sparse.colptr[j + 1] - 1)] .+ ((ns + nc) * N))
+
+        J_colptr[j + 1] = J_colptr[j] + A_offset + E_offset + K_offset
+    end
+
+    # Set the remaining block columns corresponding to states: -I, A, E, K
+    for i in 2:N
+        for j in 1:ns
+            J_nzval[J_colptr[j + (i - 1) * ns]]  = T(-1)
+            J_rowval[J_colptr[j + (i - 1) * ns]] = ns * (i - 2) + j
+
+            A_offset = length(A.colptr[j]:(A.colptr[j + 1] - 1))
+
+            J_nzval[(J_colptr[j + (i - 1) * ns] + 1):(J_colptr[j + (i - 1) * ns] + 1 + A_offset - 1)]  = A.nzval[A.colptr[j]:(A.colptr[j + 1] - 1)]
+            J_rowval[(J_colptr[j + (i - 1) * ns] + 1):(J_colptr[j + (i - 1) * ns] + 1 + A_offset - 1)] = A.rowval[A.colptr[j]:(A.colptr[j + 1] - 1)] .+ (ns * (i - 1))
+
+            E_offset = length(E.colptr[j]:(E.colptr[j + 1] - 1))
+
+            (J_nzval[(J_colptr[j + (i - 1) * ns] + 1 + A_offset):(J_colptr[j + (i - 1) * ns] + 1 + A_offset + E_offset - 1)]
+                = E.nzval[E.colptr[j]:(E.colptr[j + 1] - 1)])
+            (J_rowval[(J_colptr[j + (i - 1) * ns] + 1 + A_offset):(J_colptr[j + (i - 1) * ns] + 1 + A_offset + E_offset - 1)]
+                = E.rowval[E.colptr[j]:(E.colptr[j + 1] - 1)] .+ (ns * N + nc * (i - 1)))
+
+            K_offset = length(K_sparse.colptr[j]:(K_sparse.colptr[j + 1] - 1))
+
+            (J_nzval[(J_colptr[j + (i - 1) * ns] + 1 + A_offset + E_offset):(J_colptr[j + (i - 1) * ns] + 1 + A_offset + E_offset + K_offset - 1)]
+                = K_sparse.nzval[K_sparse.colptr[j]:(K_sparse.colptr[j + 1] - 1)])
+            (J_rowval[(J_colptr[j + (i - 1) * ns] + 1 + A_offset + E_offset):(J_colptr[j + (i - 1) * ns] + 1 + A_offset + E_offset + K_offset - 1)]
+                = K_sparse.rowval[K_sparse.colptr[j]:(K_sparse.colptr[j + 1] - 1)] .+ ((ns + nc) * N + nb * (i - 1)))
+
+            J_colptr[ns * (i - 1) + j + 1] = J_colptr[ns * (i - 1) + j] + 1 + A_offset + E_offset + K_offset
+        end
+    end
+
+    # Set the column corresponding to states at N + 1, which are a single block of -I
+    for j in 1:ns
+        J_nzval[J_colptr[ns * N + j]]  = T(-1)
+        J_rowval[J_colptr[ns * N + j]] = ns * (N - 1) + j
+        J_colptr[ns * N + j + 1] = J_colptr[ns * N + j] + 1
+    end
+
+    # Set the remaining block columns corresponding to inputs: B, F, I
+    for i in 1:N
+        offset = ns * (N + 1) + nu * (i - 1)
+        for j in 1:nu
+            B_offset = length(B.colptr[j]:(B.colptr[j + 1] - 1))
+
+            J_nzval[(J_colptr[offset + j]):(J_colptr[offset + j] + B_offset - 1)]  = B.nzval[B.colptr[j]:(B.colptr[j + 1] - 1)]
+            J_rowval[(J_colptr[offset + j]):(J_colptr[offset + j] + B_offset - 1)] = B.rowval[B.colptr[j]:(B.colptr[j + 1] - 1)] .+ (ns * (i -1))
+
+            F_offset = length(F.colptr[j]:(F.colptr[j + 1] - 1))
+
+            (J_nzval[(J_colptr[offset + j] + B_offset):(J_colptr[offset + j] + B_offset + F_offset - 1)]
+                = F.nzval[F.colptr[j]:(F.colptr[j + 1] - 1)])
+            (J_rowval[(J_colptr[offset + j] + B_offset):(J_colptr[offset + j] + B_offset + F_offset - 1)]
+                = F.rowval[F.colptr[j]:(F.colptr[j + 1] - 1)] .+ (ns * N + nc * (i - 1)))
+
+            KI_offset = length(KI.colptr[j]:(KI.colptr[j + 1] - 1))
+
+            (J_nzval[(J_colptr[offset + j] + B_offset + F_offset):(J_colptr[offset + j] + B_offset + F_offset + KI_offset - 1)]
+                = KI.nzval[KI.colptr[j]:(KI.colptr[j + 1] - 1)])
+            (J_rowval[(J_colptr[offset + j] + B_offset + F_offset):(J_colptr[offset + j] + B_offset + F_offset + KI_offset - 1)]
+                = KI.rowval[KI.colptr[j]:(KI.colptr[j + 1] - 1)] .+ ((ns + nc) * N + nb * (i - 1)))
+
+            J_colptr[offset + j + 1] = J_colptr[offset + j] + B_offset + F_offset + KI_offset
+        end
+    end
+end
+
+function _set_sparse_J!(
+    J_colptr, J_rowval, J_nzval,
+    A::M, B::M, E::M, F::M, K::MK, N
+) where {T, M <: SparseMatrixCSC{T}, MK <: Nothing}
+
+    ns = size(A, 2)
+    nu = size(B, 2)
+    nc = size(E, 1)
+
+    J_colptr[1] = 1
+    # Set the first block column of A, E, and K
+    for j in 1:ns
+        A_offset = length(A.colptr[j]:(A.colptr[j + 1] - 1))
+        J_nzval[(J_colptr[j]):(J_colptr[j] + A_offset - 1)]  = A.nzval[A.colptr[j]:(A.colptr[j + 1] - 1)]
+        J_rowval[(J_colptr[j]):(J_colptr[j] + A_offset - 1)] = A.rowval[A.colptr[j]:(A.colptr[j + 1] - 1)]
+
+        E_offset = length(E.colptr[j]:(E.colptr[j + 1] - 1))
+
+        J_nzval[(J_colptr[j] + A_offset):(J_colptr[j] + A_offset + E_offset - 1)]  = E.nzval[E.colptr[j]:(E.colptr[j + 1] - 1)]
+        J_rowval[(J_colptr[j] + A_offset):(J_colptr[j] + A_offset + E_offset - 1)] = E.rowval[E.colptr[j]:(E.colptr[j + 1] - 1)] .+ (ns * N)
+
+        J_colptr[j + 1] = J_colptr[j] + A_offset + E_offset
+    end
+
+    # Set the remaining block columns corresponding to states: -I, A, E
+    for i in 2:N
+        for j in 1:ns
+            J_nzval[J_colptr[j + (i - 1) * ns]]  = T(-1)
+            J_rowval[J_colptr[j + (i - 1) * ns]] = ns * (i - 2) + j
+
+            A_offset = length(A.colptr[j]:(A.colptr[j + 1] - 1))
+
+            J_nzval[(J_colptr[j + (i - 1) * ns] + 1):(J_colptr[j + (i - 1) * ns] + 1 + A_offset - 1)]  = A.nzval[A.colptr[j]:(A.colptr[j + 1] - 1)]
+            J_rowval[(J_colptr[j + (i - 1) * ns] + 1):(J_colptr[j + (i - 1) * ns] + 1 + A_offset - 1)] = A.rowval[A.colptr[j]:(A.colptr[j + 1] - 1)] .+ (ns * (i - 1))
+
+            E_offset = length(E.colptr[j]:(E.colptr[j + 1] - 1))
+
+            (J_nzval[(J_colptr[j + (i - 1) * ns] + 1 + A_offset):(J_colptr[j + (i - 1) * ns] + 1 + A_offset + E_offset - 1)]
+                = E.nzval[E.colptr[j]:(E.colptr[j + 1] - 1)])
+            (J_rowval[(J_colptr[j + (i - 1) * ns] + 1 + A_offset):(J_colptr[j + (i - 1) * ns] + 1 + A_offset + E_offset - 1)]
+                = E.rowval[E.colptr[j]:(E.colptr[j + 1] - 1)] .+ (ns * N + nc * (i - 1)))
+
+            J_colptr[ns * (i - 1) + j + 1] = J_colptr[ns * (i - 1) + j] + 1 + A_offset + E_offset
+        end
+    end
+
+    # Set the column corresponding to states at N + 1, which are a single block of -I
+    for j in 1:ns
+        J_nzval[J_colptr[ns * N + j]]  = T(-1)
+        J_rowval[J_colptr[ns * N + j]] = ns * (N - 1) + j
+        J_colptr[ns * N + j + 1] = J_colptr[ns * N + j] + 1
+    end
+
+    # Set the remaining block columns corresponding to inputs: B, F
+    for i in 1:N
+        offset = ns * (N + 1) + nu * (i - 1)
+        for j in 1:nu
+            B_offset = length(B.colptr[j]:(B.colptr[j + 1] - 1))
+
+            J_nzval[(J_colptr[offset + j]):(J_colptr[offset + j] + B_offset - 1)]  = B.nzval[B.colptr[j]:(B.colptr[j + 1] - 1)]
+            J_rowval[(J_colptr[offset + j]):(J_colptr[offset + j] + B_offset - 1)] = B.rowval[B.colptr[j]:(B.colptr[j + 1] - 1)] .+ (ns * (i -1))
+
+            F_offset = length(F.colptr[j]:(F.colptr[j + 1] - 1))
+
+            (J_nzval[(J_colptr[offset + j] + B_offset):(J_colptr[offset + j] + B_offset + F_offset - 1)]
+                = F.nzval[F.colptr[j]:(F.colptr[j + 1] - 1)])
+            (J_rowval[(J_colptr[offset + j] + B_offset):(J_colptr[offset + j] + B_offset + F_offset - 1)]
+                = F.rowval[F.colptr[j]:(F.colptr[j + 1] - 1)] .+ (ns * N + nc * (i - 1)))
+
+            J_colptr[offset + j + 1] = J_colptr[offset + j] + B_offset + F_offset
+        end
+    end
 end

--- a/src/LinearQuadratic/sparse.jl
+++ b/src/LinearQuadratic/sparse.jl
@@ -338,6 +338,15 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
 
     nc = size(E, 1)
 
+    dropzeros!(A)
+    dropzeros!(B)
+    dropzeros!(Q)
+    dropzeros!(R)
+    dropzeros!(Qf)
+    dropzeros!(E)
+    dropzeros!(F)
+    dropzeros!(S)
+
     H_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
     H_rowval = zeros(Int, length(Q.rowval) * N + length(R.rowval) * N + 2 * length(S.rowval) * N + length(Qf.rowval))
     H_nzval  = zeros(T, length(Q.nzval) * N + length(R.nzval) * N + 2 * length(S.nzval) * N + length(Qf.nzval))
@@ -353,9 +362,6 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     _set_sparse_J!(J_colptr, J_rowval, J_nzval, A, B, E, F, K, N)
 
     J = SparseArrays.SparseMatrixCSC((nc + ns) * N, (N + 1) * ns + nu * N, J_colptr, J_rowval, J_nzval)
-
-    SparseArrays.dropzeros!(H)
-    SparseArrays.dropzeros!(J)
 
     c0  = zero(T)
 
@@ -440,6 +446,16 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
 
     nc = size(E, 1)
 
+    dropzeros!(A)
+    dropzeros!(B)
+    dropzeros!(Q)
+    dropzeros!(R)
+    dropzeros!(Qf)
+    dropzeros!(E)
+    dropzeros!(F)
+    dropzeros!(S)
+    dropzeros!(K)
+
     bool_vec        = (ul .!= -Inf .|| uu .!= Inf)
     num_real_bounds = sum(bool_vec)
 
@@ -478,6 +494,11 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     LinearAlgebra.mul!(FK, F, K)
     LinearAlgebra.axpy!(1, FK, new_E)
 
+    dropzeros!(new_Q)
+    dropzeros!(new_A)
+    dropzeros!(new_E)
+    dropzeros!(new_S)
+
     K_sparse = K[bool_vec, :]
 
     H_colptr = zeros(Int, ns * (N + 1) + nu * N + 1)
@@ -497,9 +518,6 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     _set_sparse_J!(J_colptr, J_rowval, J_nzval, new_A, B, new_E, F, K, bool_vec, N, num_real_bounds)
 
     J = SparseArrays.SparseMatrixCSC(ns * N + nc * N + num_real_bounds * N, (N + 1) * ns + nu * N, J_colptr, J_rowval, J_nzval)
-
-    SparseArrays.dropzeros!(H)
-    SparseArrays.dropzeros!(J)
 
     # Remove algebraic constraints if u variable is unbounded on both upper and lower ends
     lcon3 = _init_similar(ul, nu * N, T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,6 +108,17 @@ function dynamic_data_to_CUDA(dnlp::LQDynamicData)
     )
 end
 
+function test_sparse_support(lqdm)
+d = lqdm.dynamic_data
+
+(lqdm_sparse_data = SparseLQDynamicModel(d.s0, sparse(d.A), sparse(d.B), sparse(d.Q), sparse(d.R), d.N;
+    sl = d.sl, ul = d.ul, su = d.su, uu = d.uu, Qf = sparse(d.Qf), K = (d.K == nothing ? nothing : sparse(d.K)),
+    S = sparse(d.S), E = sparse(d.E), F = sparse(d.F), gl = d.gl, gu = d.gu))
+
+@test lqdm.data.H ≈ lqdm_sparse_data.data.H atol = 1e-10
+@test lqdm.data.A ≈ lqdm_sparse_data.data.A atol = 1e-10
+end
+
 function runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
     optimize!(model)
     solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
@@ -131,6 +142,8 @@ function runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dens
     @test u_values ≈ get_u(solution_ref_sparse, lq_sparse) atol = 1e-7
     @test s_values ≈ get_s(solution_ref_dense, lq_dense) atol = 1e-5
     @test u_values ≈ get_u(solution_ref_dense, lq_dense) atol = 1e-5
+
+    test_sparse_support(lq_sparse)
 
     lq_dense_imp = DenseLQDynamicModel(dnlp; implicit = true)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,14 +109,14 @@ function dynamic_data_to_CUDA(dnlp::LQDynamicData)
 end
 
 function test_sparse_support(lqdm)
-d = lqdm.dynamic_data
+    d = lqdm.dynamic_data
 
-(lqdm_sparse_data = SparseLQDynamicModel(d.s0, sparse(d.A), sparse(d.B), sparse(d.Q), sparse(d.R), d.N;
-    sl = d.sl, ul = d.ul, su = d.su, uu = d.uu, Qf = sparse(d.Qf), K = (d.K == nothing ? nothing : sparse(d.K)),
-    S = sparse(d.S), E = sparse(d.E), F = sparse(d.F), gl = d.gl, gu = d.gu))
+    (lqdm_sparse_data = SparseLQDynamicModel(d.s0, sparse(d.A), sparse(d.B), sparse(d.Q), sparse(d.R), d.N;
+        sl = d.sl, ul = d.ul, su = d.su, uu = d.uu, Qf = sparse(d.Qf), K = (d.K == nothing ? nothing : sparse(d.K)),
+        S = sparse(d.S), E = sparse(d.E), F = sparse(d.F), gl = d.gl, gu = d.gu))
 
-@test lqdm.data.H ≈ lqdm_sparse_data.data.H atol = 1e-10
-@test lqdm.data.A ≈ lqdm_sparse_data.data.A atol = 1e-10
+    @test lqdm.data.H ≈ lqdm_sparse_data.data.H atol = 1e-10
+    @test lqdm.data.A ≈ lqdm_sparse_data.data.A atol = 1e-10
 end
 
 function runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)


### PR DESCRIPTION
Added new `_build` and `_set` functions in the `sparse.jl` source code to support sparse `A, B, Q, R, K,` and `S` matrices. Currently, when the problem becomes very large, the sparse formulation is not very fast and it takes a lot of memory allocation. This is largely because the old code treated all `A, B, Q, R, K,` and `S` matrices as being dense. Now, the Hessian and Jacobian are set using the `rowval`, `nzval`, and `colptr` attributes of `A, B, Q, R, K,` and `S`. This significantly reduces the memory required to build the `SparseLQDynamicModel`. 

For N = 50, nu = 10, ns = 2000, I got the following results using `@time`
dense LQDynamicData: 18.737979 seconds (200.89 k allocations: 9.577 GiB, 9.12% gc time)
sparse LQDynamicData: 0.671002 seconds (1.51 M allocations: 134.857 MiB, 2.67% gc time)

Also added tests to ensure that the Hessian and Jacobian resulting from the new sparse functions are the same as before. 