### PR TITLE
Added functions to reset `s0` within the dense and sparse models

### DIFF
--- a/src/DynamicNLPModels.jl
+++ b/src/DynamicNLPModels.jl
@@ -10,7 +10,8 @@ import CUDA
 import CUDA: CUBLAS
 import SparseArrays: SparseMatrixCSC
 
-export LQDynamicData, SparseLQDynamicModel, DenseLQDynamicModel, get_u, get_s, get_jacobian, add_jtsj!
+export LQDynamicData, SparseLQDynamicModel, DenseLQDynamicModel
+export get_u, get_s, get_jacobian, add_jtsj!, reset_s0!
 
 include(joinpath("LinearQuadratic", "LinearQuadratic.jl"))
 include(joinpath("LinearQuadratic", "sparse.jl"))

--- a/src/LinearQuadratic/LinearQuadratic.jl
+++ b/src/LinearQuadratic/LinearQuadratic.jl
@@ -1,4 +1,3 @@
-
 abstract type AbstractLQDynData{T,V} end
 """
     LQDynamicData{T,V,M,MK} <: AbstractLQDynData{T,V}
@@ -193,15 +192,27 @@ struct SparseLQDynamicModel{T, V, M1, M2, M3, MK} <:  AbstractDynamicModel{T,V}
 end
 
 """
-Struct containing block A and B matrices used in creating the `DenseLQDynamicModel`. These matrices are given by Jerez, Kerrigan, and Constantinides
+Struct containing block A and B matrices used in creating the `DenseLQDynamicModel`. These matrices are given in part by Jerez, Kerrigan, and Constantinides
 in section 4 of "A sparse and condensed QP formulation for predictive control of LTI systems" (doi:10.1016/j.automatica.2012.03.010).
 
 `A` is a ns(N+1) x ns matrix and `B` is a ns(N) x nu matrix containing the first column of the `B` block matrix in the above text. Note that the
 first block of zeros is omitted.
+
+The blocks `h`, `h0`, `d` and `KA` store data needed to reset the `DenseLQDynamicModel` when `s0` is redefined.
+
+See also `reset_s0!`
 """
 struct DenseLQDynamicBlocks{T, M}
+    # block_h0 = A^T((Q + KTRK + 2 * SK))A where Q, K, R, S, and A are block matrices
+    # block_h  = (QB + SKB + K^T R K B + K^T S^T B)^T A + (S + K^T R)^T A
+    # block_d  = (E + FK) A
+    # block_KA = KA
     A::M
     B::M
+    h::M
+    h0::M
+    d::M
+    KA::M
 end
 
 struct DenseLQDynamicModel{T, V, M1, M2, M3, M4, MK} <:  AbstractDynamicModel{T,V}
@@ -211,7 +222,6 @@ struct DenseLQDynamicModel{T, V, M1, M2, M3, M4, MK} <:  AbstractDynamicModel{T,
     dynamic_data::LQDynamicData{T, V, M3, MK}
     blocks::DenseLQDynamicBlocks{T, M4}
 end
-
 
 """
     LQJacobianOperator{T, V, M}

--- a/src/LinearQuadratic/dense.jl
+++ b/src/LinearQuadratic/dense.jl
@@ -970,8 +970,6 @@ function _set_G_blocks!(
     EB   = _init_similar(block_B, nc, nu, T)
     EA   = _init_similar(block_B, nc, ns, T)
 
-    #LinearAlgebra.mul!(As0, block_A, s0)
-
     for i in 1:N
         if i != N
             B_row_range = (1 + (i - 1) * ns):(i * ns)

--- a/test/functions.jl
+++ b/test/functions.jl
@@ -1,0 +1,189 @@
+function test_mul(lq_dense, lq_dense_imp)
+    dnlp = lq_dense.dynamic_data
+    N    = dnlp.N
+    nu   = dnlp.nu
+
+    J     = get_jacobian(lq_dense)
+    J_imp = get_jacobian(lq_dense_imp)
+
+    Random.seed!(10)
+    x = rand(nu * N)
+    y = rand(size(J, 1))
+
+    x_imp = similar(lq_dense_imp.dynamic_data.s0, length(x))
+    y_imp = similar(lq_dense_imp.dynamic_data.s0, length(y))
+    LinearAlgebra.copyto!(x_imp, x)
+    LinearAlgebra.copyto!(y_imp, y)
+
+    LinearAlgebra.mul!(y, J, x)
+    LinearAlgebra.mul!(y_imp, J_imp, x_imp)
+
+    @test y ≈ Vector(y_imp) atol = 1e-14
+
+    x = rand(nu * N)
+    y = rand(size(J, 1))
+
+    x_imp = similar(lq_dense_imp.dynamic_data.s0, length(x))
+    y_imp = similar(lq_dense_imp.dynamic_data.s0, length(y))
+    LinearAlgebra.copyto!(x_imp, x)
+    LinearAlgebra.copyto!(y_imp, y)
+
+    LinearAlgebra.mul!(x, J', y)
+    LinearAlgebra.mul!(x_imp, J_imp', y_imp)
+
+    @test x ≈ Vector(x_imp) atol = 1e-14
+end
+
+function test_add_jtsj(lq_dense, lq_dense_imp)
+    dnlp = lq_dense.dynamic_data
+    N    = dnlp.N
+    nu   = dnlp.nu
+
+    H     = zeros(nu * N, nu * N)
+
+    Random.seed!(10)
+    J     = get_jacobian(lq_dense)
+    J_imp = get_jacobian(lq_dense_imp)
+    ΣJ    = similar(J); fill!(ΣJ, 0)
+
+    x     = rand(size(J, 1))
+
+    H_imp = similar(lq_dense_imp.data.H, nu * N, nu * N); fill!(H_imp, 0)
+    x_imp = similar(lq_dense_imp.dynamic_data.s0, length(x));
+    LinearAlgebra.copyto!(x_imp, x)
+
+    LinearAlgebra.mul!(ΣJ, Diagonal(x), J)
+    LinearAlgebra.mul!(H, J', ΣJ)
+
+    add_jtsj!(H_imp, J_imp, x_imp)
+
+    @test LowerTriangular(Array(H_imp)) ≈ LowerTriangular(H) atol = 1e-10
+end
+
+function dynamic_data_to_CUDA(dnlp::LQDynamicData)
+    s0c = CuVector{Float64}(undef, length(dnlp.s0))
+    Ac  = CuArray{Float64}(undef, size(dnlp.A))
+    Bc  = CuArray{Float64}(undef, size(dnlp.B))
+    Qc  = CuArray{Float64}(undef, size(dnlp.Q))
+    Rc  = CuArray{Float64}(undef, size(dnlp.R))
+    Sc  = CuArray{Float64}(undef, size(dnlp.S))
+    Ec  = CuArray{Float64}(undef, size(dnlp.E))
+    Fc  = CuArray{Float64}(undef, size(dnlp.F))
+    Qfc = CuArray{Float64}(undef, size(dnlp.Qf))
+    glc = CuVector{Float64}(undef, length(dnlp.gl))
+    guc = CuVector{Float64}(undef, length(dnlp.gu))
+    ulc = CuVector{Float64}(undef, length(dnlp.ul))
+    uuc = CuVector{Float64}(undef, length(dnlp.uu))
+    slc = CuVector{Float64}(undef, length(dnlp.sl))
+    suc = CuVector{Float64}(undef, length(dnlp.su))
+
+    LinearAlgebra.copyto!(Ac, dnlp.A)
+    LinearAlgebra.copyto!(Bc, dnlp.B)
+    LinearAlgebra.copyto!(Qc, dnlp.Q)
+    LinearAlgebra.copyto!(Rc, dnlp.R)
+    LinearAlgebra.copyto!(s0c, dnlp.s0)
+    LinearAlgebra.copyto!(Sc, dnlp.S)
+    LinearAlgebra.copyto!(Ec, dnlp.E)
+    LinearAlgebra.copyto!(Fc, dnlp.F)
+    LinearAlgebra.copyto!(Qfc, dnlp.Qf)
+    LinearAlgebra.copyto!(glc, dnlp.gl)
+    LinearAlgebra.copyto!(guc, dnlp.gu)
+    LinearAlgebra.copyto!(ulc, dnlp.ul)
+    LinearAlgebra.copyto!(uuc, dnlp.uu)
+    LinearAlgebra.copyto!(slc, dnlp.sl)
+    LinearAlgebra.copyto!(suc, dnlp.su)
+
+    if dnlp.K != nothing
+        Kc  = CuArray{Float64}(undef, size(dnlp.K))
+        LinearAlgebra.copyto!(Kc, dnlp.K)
+    else
+        Kc = nothing
+    end
+
+    LQDynamicData(s0c, Ac, Bc, Qc, Rc, dnlp.N; Qf = Qfc, S = Sc,
+    E = Ec, F = Fc, K = Kc, sl = slc, su = suc, ul = ulc, uu = uuc, gl = glc, gu = guc
+    )
+end
+
+function test_sparse_support(lqdm)
+    d = lqdm.dynamic_data
+
+    (lqdm_sparse_data = SparseLQDynamicModel(d.s0, sparse(d.A), sparse(d.B), sparse(d.Q), sparse(d.R), d.N;
+        sl = d.sl, ul = d.ul, su = d.su, uu = d.uu, Qf = sparse(d.Qf), K = (d.K == nothing ? nothing : sparse(d.K)),
+        S = sparse(d.S), E = sparse(d.E), F = sparse(d.F), gl = d.gl, gu = d.gu))
+
+    @test lqdm.data.H ≈ lqdm_sparse_data.data.H atol = 1e-10
+    @test lqdm.data.A ≈ lqdm_sparse_data.data.A atol = 1e-10
+end
+
+function test_dense_reset_s0(dnlp, lq_dense, new_s0)
+    lq_dense_test   = DenseLQDynamicModel(dnlp)
+    dnlp.s0 .= new_s0
+    lq_dense_new_s0 = DenseLQDynamicModel(dnlp)
+
+    reset_s0!(lq_dense_test, new_s0)
+
+    @test lq_dense_test.data.H ≈ lq_dense_new_s0.data.H atol = 1e-10
+    @test lq_dense_test.data.A ≈ lq_dense_new_s0.data.A atol = 1e-10
+    @test lq_dense_test.data.c ≈ lq_dense_new_s0.data.c atol = 1e-10
+    @test lq_dense_test.data.c0 ≈ lq_dense_new_s0.data.c0 atol = 1e-10
+
+    @test lq_dense_test.meta.lcon ≈ lq_dense_new_s0.meta.lcon atol = 1e-8
+    @test lq_dense_test.meta.ucon ≈ lq_dense_new_s0.meta.ucon atol = 1e-8
+    @test lq_dense_test.dynamic_data.s0 == lq_dense_new_s0.dynamic_data.s0
+end
+
+function test_sparse_reset_s0(dnlp, lq_sparse, new_s0)
+    reset_s0!(lq_sparse, new_s0)
+
+    @test lq_sparse.dynamic_data.s0 == new_s0
+end
+
+function runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
+    optimize!(model)
+    solution_ref_sparse           = madnlp(lq_sparse, max_iter=100)
+    solution_ref_dense            = madnlp(lq_dense, max_iter=100)
+    solution_ref_sparse_from_data = madnlp(lq_sparse_from_data, max_iter=100)
+    solution_ref_dense_from_data  = madnlp(lq_dense_from_data, max_iter=100)
+
+    @test objective_value(model) ≈ solution_ref_sparse.objective atol = 1e-7
+    @test objective_value(model) ≈ solution_ref_dense.objective atol = 1e-5
+    @test objective_value(model) ≈ solution_ref_sparse_from_data.objective atol = 1e-7
+    @test objective_value(model) ≈ solution_ref_dense_from_data.objective atol = 1e-5
+
+    @test solution_ref_sparse.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_dense.solution atol =  1e-6
+    @test solution_ref_sparse_from_data.solution[(ns * (N + 1) + 1):(ns * (N + 1) + nu*N)] ≈ solution_ref_dense_from_data.solution atol =  1e-6
+
+    # Test get_u and get_s functions with no K matrix
+    s_values = value.(all_variables(model)[1:(ns * (N + 1))])
+    u_values = value.(all_variables(model)[(1 + ns * (N + 1)):(ns * (N + 1) + nu * N)])
+
+    @test s_values ≈ get_s(solution_ref_sparse, lq_sparse) atol = 1e-7
+    @test u_values ≈ get_u(solution_ref_sparse, lq_sparse) atol = 1e-7
+    @test s_values ≈ get_s(solution_ref_dense, lq_dense) atol = 1e-5
+    @test u_values ≈ get_u(solution_ref_dense, lq_dense) atol = 1e-5
+
+    test_sparse_support(lq_sparse)
+
+    lq_dense_imp = DenseLQDynamicModel(dnlp; implicit = true)
+
+    imp_test_set = []
+    push!(imp_test_set, lq_dense_imp)
+
+    if CUDA.has_cuda_gpu()
+        dnlp_cuda     = dynamic_data_to_CUDA(dnlp)
+        lq_dense_cuda = DenseLQDynamicModel(dnlp_cuda; implicit=true)
+        push!(imp_test_set, lq_dense_cuda)
+    end
+
+    @testset "Test mul and add_jtsj!" for lq_imp in imp_test_set
+        test_mul(lq_dense, lq_imp)
+        test_add_jtsj(lq_dense, lq_imp)
+    end
+
+    new_s0 = copy(dnlp.s0) .+ .5
+    test_dense_reset_s0(dnlp, lq_dense, new_s0)
+
+    new_s0 = copy(dnlp.s0) .+ 1
+    test_sparse_reset_s0(dnlp, lq_sparse, new_s0)
+end


### PR DESCRIPTION
After each sample period, the new initial states, `s0`, need to be reset within the model. This PR adds support for resetting that value within the dynamic data and impacted parts of the dynamic model. The function `reset_s0!` is now exported so that the user can reset this value. In addition, I added tests for this function within `runtests.jl` and I reformatted the `test/` subdirectory slightly so that all of the functions are in their own file. 

In the sparse formulation, `reset_s0!` resets `s0` within the dynamic data, and it resets the variable bounds on `s` at time 0 (thus fixing the first state to the value of `s0`. 

For the dense formulation, `reset_s0!` resets `s0` in the dynamic data, and it also calculates a new linear and constant term in the objective function. It  also changes the impacted constraint bounds for the Jacobian. Because resetting `s0` should be a quick and efficient call, I added blocks to the `DenseLQDynamicBlocks` that store the matrices needed to get the new linear and constant terms and for calculating the new constraint bounds. This also meant reconfiguring the functions `_build_H_blocks` and `_set_G_blocks!`. The data within `DenseLQDynamicBlocks` is designed to just be multiplied by `s0` to get the desired final values. 