### PR TITLE
Added support for constant term in the linear dynamic constraints

### DIFF
--- a/src/LinearQuadratic/LinearQuadratic.jl
+++ b/src/LinearQuadratic/LinearQuadratic.jl
@@ -211,7 +211,7 @@ and u = [u_0^T, u_1^T, ..., u_{N-1}^T]
 - `h`  : nu(N) x ns matrix for building the linear term of the objective function. Just needs to be
 multiplied by `s0`.
 - `h01`: ns x ns matrix for building the constant term fo the objective function. This can be found by
-taking $ s_0^T h01 s_0$
+taking  s_0^T h01 s_0
 - `h02`: similar to `h01`, but one side is multiplied by `Aw` rather than by `As0`. This will just
 be multiplied by `s0` once
 - `h_constant` : linear term in the objective function that arises from `Aw`. Not a function of `s0`

--- a/src/LinearQuadratic/LinearQuadratic.jl
+++ b/src/LinearQuadratic/LinearQuadratic.jl
@@ -6,7 +6,7 @@ A struct to represent the features of the optimization problem
 
 ```math
     minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
-    subject to  s_{i+1} = A s_i + B u_i  for i=0, 1, ..., N-1
+    subject to  s_{i+1} = A s_i + B u_i + w  for i=0, 1, ..., N-1
                 u_i = Kx_i + v_i  \\forall i = 0, 1, ..., N - 1
                 gl \\le E s_i + F u_i \\le gu for i = 0, 1, ..., N-1
                 sl \\le s \\le su
@@ -28,6 +28,7 @@ Attributes include:
 - `E` : constraint matrix for state variables
 - `F` : constraint matrix for input variables
 - `K` : feedback gain matrix
+- 'w' : constant term for dynamic constraints
 - `sl`: vector of lower bounds on state variables
 - `su`: vector of upper bounds on state variables
 - `ul`: vector of lower bounds on input variables
@@ -52,6 +53,7 @@ struct LQDynamicData{T, V, M, MK} <: AbstractLQDynData{T,V}
     E::M
     F::M
     K::MK
+    w::V
 
     sl::V
     su::V
@@ -89,6 +91,7 @@ The following keyward arguments are also accepted
 - `E  = zeros(eltype(Q), 0, ns)`  : constraint matrix for state variables
 - `F  = zeros(eltype(Q), 0, nu)`  : constraint matrix for input variables
 - `K  = nothing`       : feedback gain matrix
+- `w  = zeros(eltype(Q), ns)`     : constant term for dynamic constraints
 - `sl = fill(-Inf, ns)`: vector of lower bounds on state variables
 - `su = fill(Inf, ns)` : vector of upper bounds on state variables
 - `ul = fill(-Inf, nu)`: vector of lower bounds on input variables
@@ -109,6 +112,7 @@ function LQDynamicData(
     E::M  = _init_similar(Q, 0, length(s0), T),
     F::M  = _init_similar(Q, 0, size(R, 1), T),
     K::MK = nothing,
+    w::V  = _init_similar(s0, length(s0, T)),
 
     sl::V = (similar(s0) .= -Inf),
     su::V = (similar(s0) .=  Inf),

--- a/src/LinearQuadratic/LinearQuadratic.jl
+++ b/src/LinearQuadratic/LinearQuadratic.jl
@@ -199,13 +199,29 @@ struct SparseLQDynamicModel{T, V, M1, M2, M3, MK} <:  AbstractDynamicModel{T,V}
 end
 
 """
-Struct containing block A and B matrices used in creating the `DenseLQDynamicModel`. These matrices are given in part by Jerez, Kerrigan, and Constantinides
-in section 4 of "A sparse and condensed QP formulation for predictive control of LTI systems" (doi:10.1016/j.automatica.2012.03.010).
+Struct containing block matrices used for creating and resetting the `DenseLQDynamicModel`. A and B matrices are given in part by
+Jerez, Kerrigan, and Constantinides in section 4 of "A sparse and condensed QP formulation for predictive control of LTI systems"
+(doi:10.1016/j.automatica.2012.03.010). States are eliminated by the equation $ x = Ax_0 + Bu + \hat{A}w$ where $ x = [x_0^T, x_1^T, ..., x_N^T]$
+and $ u = [u_0^T, u_1^T, ..., u_{N-1}^T]$
 
-`A` is a ns(N+1) x ns matrix and `B` is a ns(N) x nu matrix containing the first column of the `B` block matrix in the above text. Note that the
-first block of zeros is omitted.
-
-The blocks `h`, `h0`, `d` and `KA` store data needed to reset the `DenseLQDynamicModel` when `s0` is redefined.
+---
+- `A`  : block A matrix given by Jerez et al. with ns(N + 1) rows and ns columns
+- `B`  : block B matrix given by Jerez et al. with ns(N) rows and nu columns
+- `Aw` : length ns(N + 1) vector corresponding to the linear term of the dynamic constraints
+- `h`  : nu(N) x ns matrix for building the linear term of the objective function. Just needs to be
+multiplied by `s0`.
+- `h01`: ns x ns matrix for building the constant term fo the objective function. This can be found by
+taking $ s_0^T h01 s_0$
+- `h02`: similar to `h01`, but one side is multiplied by `Aw` rather than by `As0`. This will just
+be multiplied by `s0` once
+- `h_constant` : linear term in the objective function that arises from `Aw`. Not a function of `s0`
+- `h0_constant`: constant term in the objective function that arises from `Aw`. Not a function of `s0`
+- `d`  : length nc(N) term for the constraint bounds corresponding to `E` and `F`. Must be multiplied by `s0` and
+subtracted from `gl` and `gu`. Equal to the blocks (E + FK) A (see Jerez et al.)
+- `dw` : length nc(N) term for the constraint bounds that arises from `w`. Equal to (E + FK) Aw
+- `KA` : size nu(N) x ns matrix. Needs to be multiplied by `s0` and subtracted from `ul` and `uu` to updated
+the algebraic constraints corresponding to the input bounds
+- `KAw`: similar to `KA`, but it is already multiplied by `w`.
 
 See also `reset_s0!`
 """

--- a/src/LinearQuadratic/LinearQuadratic.jl
+++ b/src/LinearQuadratic/LinearQuadratic.jl
@@ -68,7 +68,7 @@ end
 A constructor for building an object of type `LQDynamicData` for the optimization problem
 ```math
     minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
-    subject to  s_{i+1} = A s_i + B u_i  \\forall i=0, 1, ..., N - 1
+    subject to  s_{i+1} = A s_i + B u_i + w \\forall i=0, 1, ..., N - 1
                 u_i = Kx_i + v_i  \\forall i = 0, 1, ..., N - 1
                 gl \\le E s_i + F u_i \\le gu \\forall i = 0, 1, ..., N-1
                 sl \\le s \\le su
@@ -201,8 +201,8 @@ end
 """
 Struct containing block matrices used for creating and resetting the `DenseLQDynamicModel`. A and B matrices are given in part by
 Jerez, Kerrigan, and Constantinides in section 4 of "A sparse and condensed QP formulation for predictive control of LTI systems"
-(doi:10.1016/j.automatica.2012.03.010). States are eliminated by the equation $ x = Ax_0 + Bu + \hat{A}w$ where $ x = [x_0^T, x_1^T, ..., x_N^T]$
-and $ u = [u_0^T, u_1^T, ..., u_{N-1}^T]$
+(doi:10.1016/j.automatica.2012.03.010). States are eliminated by the equation  x = Ax_0 + Bu + \\hat{A}w where  x = [x_0^T, x_1^T, ..., x_N^T]
+and u = [u_0^T, u_1^T, ..., u_{N-1}^T]
 
 ---
 - `A`  : block A matrix given by Jerez et al. with ns(N + 1) rows and ns columns
@@ -218,10 +218,10 @@ be multiplied by `s0` once
 - `h0_constant`: constant term in the objective function that arises from `Aw`. Not a function of `s0`
 - `d`  : length nc(N) term for the constraint bounds corresponding to `E` and `F`. Must be multiplied by `s0` and
 subtracted from `gl` and `gu`. Equal to the blocks (E + FK) A (see Jerez et al.)
-- `dw` : length nc(N) term for the constraint bounds that arises from `w`. Equal to (E + FK) Aw
-- `KA` : size nu(N) x ns matrix. Needs to be multiplied by `s0` and subtracted from `ul` and `uu` to updated
+- `dw` : length nc(N) term for the constraint bounds that arises from `w`. Equal to the blocks (E + FK) Aw
+- `KA` : size nu(N) x ns matrix. Needs to be multiplied by `s0` and subtracted from `ul` and `uu` to update
 the algebraic constraints corresponding to the input bounds
-- `KAw`: similar to `KA`, but it is already multiplied by `w`.
+- `KAw`: similar to `KA`, but it is multiplied by Aw rather than A
 
 See also `reset_s0!`
 """

--- a/src/LinearQuadratic/LinearQuadratic.jl
+++ b/src/LinearQuadratic/LinearQuadratic.jl
@@ -112,7 +112,7 @@ function LQDynamicData(
     E::M  = _init_similar(Q, 0, length(s0), T),
     F::M  = _init_similar(Q, 0, size(R, 1), T),
     K::MK = nothing,
-    w::V  = _init_similar(s0, length(s0, T)),
+    w::V  = _init_similar(s0, length(s0), T),
 
     sl::V = (similar(s0) .= -Inf),
     su::V = (similar(s0) .=  Inf),
@@ -209,7 +209,7 @@ The blocks `h`, `h0`, `d` and `KA` store data needed to reset the `DenseLQDynami
 
 See also `reset_s0!`
 """
-struct DenseLQDynamicBlocks{T, V, M}
+mutable struct DenseLQDynamicBlocks{T, V, M}
     # Aw = block_matrix_A * w (result is a Vector; block_matrix A is like block_B,
     # but with I instead of B)
     # h  = (QB + SKB + K^T R K B + K^T S^T B)^T A + (S + K^T R)^T A
@@ -228,10 +228,11 @@ struct DenseLQDynamicBlocks{T, V, M}
     h01::M
     h02::V
     h_constant::V
-    h0_constant::V
+    h0_constant::T
     d::M
     dw::V
     KA::M
+    KAw::V
 end
 
 struct DenseLQDynamicModel{T, V, M1, M2, M3, M4, MK} <:  AbstractDynamicModel{T,V}
@@ -239,7 +240,7 @@ struct DenseLQDynamicModel{T, V, M1, M2, M3, M4, MK} <:  AbstractDynamicModel{T,
     counters::NLPModels.Counters
     data::QuadraticModels.QPData{T, V, M1, M2}
     dynamic_data::LQDynamicData{T, V, M3, MK}
-    blocks::DenseLQDynamicBlocks{T, v, M4}
+    blocks::DenseLQDynamicBlocks{T, V, M4}
 end
 
 """

--- a/src/LinearQuadratic/dense.jl
+++ b/src/LinearQuadratic/dense.jl
@@ -743,8 +743,8 @@ end
 
 
 function _build_block_matrices(
-    A::M, B::M, K, N, nc
-) where {T, M <: AbstractMatrix{T}}
+    A::M, B::M, K, N, w::V, nc
+) where {T, V <: AbstractVector{T}, M <: AbstractMatrix{T}}
 
     ns = size(A, 2)
     nu = size(B, 2)
@@ -754,12 +754,17 @@ function _build_block_matrices(
     end
 
     # Define block matrices
-    block_A  = _init_similar(A, ns * (N + 1), ns, T)
-    block_B  = _init_similar(B, ns * N, nu, T)
-    block_h  = _init_similar(A, nu * N, ns, T)
-    block_h0 = _init_similar(A, ns, ns, T)
-    block_d  = _init_similar(A, nc * N, ns, T)
-    block_KA = _init_similar(A, nu * N, ns, T)
+    block_A   = _init_similar(A, ns * (N + 1), ns, T)
+    block_B   = _init_similar(B, ns * N, nu, T)
+    block_Aw  = _init_similar(w, ns * N, T)
+    block_h   = _init_similar(A, nu * N, ns, T)
+    block_h01 = _init_similar(A, ns, ns, T)
+    block_h02 = _init_similar(w, ns * N, T)
+    h_const   = _init_similar(w, nu * N, T)
+    h0_const  = _init_similar(w, 1, T)
+    block_d   = _init_similar(A, nc * N, ns, T)
+    block_dw  = _init_similar(A, nc * N, ns, T)
+    block_KA  = _init_similar(A, nu * N, ns, T)
 
     A_k = copy(A)
     BK  = _init_similar(A, ns, ns, T)
@@ -810,12 +815,17 @@ function _build_block_matrices(
 
     block_A[(ns * N + 1):ns * (N + 1), :] = A_knext
 
-    DenseLQDynamicBlocks{T, M}(
+    DenseLQDynamicBlocks{T, V, M}(
         block_A,
         block_B,
+        block_Aw,
         block_h,
-        block_h0,
+        block_h01,
+        block_h02,
+        h_const,
+        h0_const,
         block_d,
+        block_dw,
         block_KA
     )
 end

--- a/src/LinearQuadratic/dense.jl
+++ b/src/LinearQuadratic/dense.jl
@@ -87,6 +87,7 @@ function _build_dense_lq_dynamic_model(
     E  = dnlp.E
     F  = dnlp.F
     K  = dnlp.K
+    w  = dnlp.w
 
     sl = dnlp.sl
     su = dnlp.su
@@ -100,17 +101,22 @@ function _build_dense_lq_dynamic_model(
     bool_vec_s        = (su .!= Inf .|| sl .!= -Inf)
     num_real_bounds_s = sum(bool_vec_s)
 
-    dense_blocks = _build_block_matrices(A, B, K, N, nc)
+    dense_blocks = _build_block_matrices(A, B, K, N, w, nc)
     block_A  = dense_blocks.A
     block_B  = dense_blocks.B
     block_d  = dense_blocks.d
+    block_Aw = dense_blocks.Aw
+    block_dw = dense_blocks.dw
 
-    H_blocks = _build_H_blocks(Q, R, block_A, block_B, S,Qf, K, s0, N)
+    H_blocks = _build_H_blocks(Q, R, block_A, block_B, block_Aw, S,Qf, K, s0, N)
 
     H  = H_blocks.H
     c0 = H_blocks.c0
-    dense_blocks.h  .= H_blocks.block_h
-    dense_blocks.h0 .= H_blocks.block_h0
+    dense_blocks.h   .= H_blocks.block_h
+    dense_blocks.h01 .= H_blocks.block_h01
+    dense_blocks.h02 .= H_blocks.block_h02
+    dense_blocks.h_constant  .= H_blocks.h_constant
+    dense_blocks.h0_constant = H_blocks.h0_constant
 
     G  = _init_similar(Q, nc * N, nu, T)
     J  = _init_similar(Q, nc * N + num_real_bounds_s * N, nu * N, T)
@@ -119,7 +125,7 @@ function _build_dense_lq_dynamic_model(
     dl = repeat(gl, N)
     du = repeat(gu, N)
 
-    _set_G_blocks!(G, dl, du, block_B, block_A, block_d, s0, E, F, K, N)
+    _set_G_blocks!(G, dl, du, block_B, block_A, block_d, block_Aw, block_dw, s0, E, F, K, N)
     _set_J1_dense!(J, G, N)
 
     As0 = _init_similar(s0, ns * (N + 1), T)
@@ -218,6 +224,7 @@ function _build_dense_lq_dynamic_model(
     E  = dnlp.E
     F  = dnlp.F
     K  = dnlp.K
+    w  = dnlp.w
 
     sl = dnlp.sl
     su = dnlp.su
@@ -228,17 +235,22 @@ function _build_dense_lq_dynamic_model(
 
     nc = size(E, 1)
 
-    dense_blocks = _build_block_matrices(A, B, K, N, nc)
+    dense_blocks = _build_block_matrices(A, B, K, N, w, nc)
     block_A  = dense_blocks.A
     block_B  = dense_blocks.B
     block_d  = dense_blocks.d
+    block_Aw = dense_blocks.Aw
+    block_dw = dense_blocks.dw
 
-    H_blocks = _build_H_blocks(Q, R, block_A, block_B, S, Qf, K, s0, N)
+    H_blocks = _build_H_blocks(Q, R, block_A, block_B, block_Aw, S,Qf, K, s0, N)
 
     H  = H_blocks.H
     c0 = H_blocks.c0
-    dense_blocks.h  .= H_blocks.block_h
-    dense_blocks.h0 .= H_blocks.block_h0
+    dense_blocks.h   .= H_blocks.block_h
+    dense_blocks.h01 .= H_blocks.block_h01
+    dense_blocks.h02 .= H_blocks.block_h02
+    dense_blocks.h_constant  .= H_blocks.h_constant
+    dense_blocks.h0_constant = H_blocks.h0_constant
 
     bool_vec_s        = (su .!= Inf .|| sl .!= -Inf)
     num_real_bounds_s   = sum(bool_vec_s)
@@ -265,7 +277,7 @@ function _build_dense_lq_dynamic_model(
     dl = repeat(gl, N)
     du = repeat(gu, N)
 
-    _set_G_blocks!(G, dl, du, block_B, block_A, block_d, s0, E, F, K, N)
+    _set_G_blocks!(G, dl, du, block_B, block_A, block_d, block_Aw, block_dw, s0, E, F, K, N)
     _set_J1_dense!(J, G, N)
 
     LinearAlgebra.mul!(As0, block_A, s0)
@@ -405,6 +417,7 @@ function _build_implicit_dense_lq_dynamic_model(
     E  = dnlp.E
     F  = dnlp.F
     K  = dnlp.K
+    w  = dnlp.w
 
     sl = dnlp.sl
     su = dnlp.su
@@ -443,23 +456,27 @@ function _build_implicit_dense_lq_dynamic_model(
     SJ3  = _init_similar(Q, 0, nu, T)
     H_sub_block = _init_similar(Q, nu, nu, T)
 
-    dense_blocks = _build_block_matrices(A, B, K, N, nc)
+    dense_blocks = _build_block_matrices(A, B, K, N, w, nc)
     block_A      = dense_blocks.A
     block_B      = dense_blocks.B
     block_d      = dense_blocks.d
+    block_Aw = dense_blocks.Aw
+    block_dw = dense_blocks.dw
 
-    H_blocks = _build_H_blocks(Q, R, block_A, block_B, S,Qf, K, s0, N)
+    H_blocks = _build_H_blocks(Q, R, block_A, block_B, block_Aw, S,Qf, K, s0, N)
 
     H  = H_blocks.H
     c0 = H_blocks.c0
-    c .= H_blocks.c
-    dense_blocks.h  .= H_blocks.block_h
-    dense_blocks.h0 .= H_blocks.block_h0
+    dense_blocks.h   .= H_blocks.block_h
+    dense_blocks.h01 .= H_blocks.block_h01
+    dense_blocks.h02 .= H_blocks.block_h02
+    dense_blocks.h_constant  .= H_blocks.h_constant
+    dense_blocks.h0_constant = H_blocks.h0_constant
 
     dl = repeat(gl, N)
     du = repeat(gu, N)
 
-    _set_G_blocks!(G, dl, du, block_B, block_A, block_d, s0, E, F, K, N)
+    _set_G_blocks!(G, dl, du, block_B, block_A, block_d, block_Aw, block_dw, s0, E, F, K, N)
     for i in 1:N
         Jac1[:, :, i] = @view G[(1 + nc * (i - 1)):(nc * i), :]
     end
@@ -554,6 +571,7 @@ function _build_implicit_dense_lq_dynamic_model(
     E  = dnlp.E
     F  = dnlp.F
     K  = dnlp.K
+    w  = dnlp.w
 
     sl = dnlp.sl
     su = dnlp.su
@@ -564,19 +582,23 @@ function _build_implicit_dense_lq_dynamic_model(
 
     nc = size(E, 1)
 
-    dense_blocks = _build_block_matrices(A, B, K, N, nc)
+    dense_blocks = _build_block_matrices(A, B, K, N, w, nc)
 
     block_A  = dense_blocks.A
     block_B  = dense_blocks.B
     block_d  = dense_blocks.d
+    block_Aw = dense_blocks.Aw
+    block_dw = dense_blocks.dw
 
-
-    H_blocks = _build_H_blocks(Q, R, block_A, block_B, S, Qf, K, s0, N)
+    H_blocks = _build_H_blocks(Q, R, block_A, block_B, block_Aw, S,Qf, K, s0, N)
 
     H  = H_blocks.H
     c0 = H_blocks.c0
-    dense_blocks.h  .= H_blocks.block_h
-    dense_blocks.h0 .= H_blocks.block_h0
+    dense_blocks.h   .= H_blocks.block_h
+    dense_blocks.h01 .= H_blocks.block_h01
+    dense_blocks.h02 .= H_blocks.block_h02
+    dense_blocks.h_constant  .= H_blocks.h_constant
+    dense_blocks.h0_constant = H_blocks.h0_constant
 
 
     bool_vec_s        = (su .!= Inf .|| sl .!= -Inf)
@@ -619,7 +641,7 @@ function _build_implicit_dense_lq_dynamic_model(
     dl = repeat(gl, N)
     du = repeat(gu, N)
 
-    _set_G_blocks!(G, dl, du, block_B, block_A, block_d, s0, E, F, K, N)
+    _set_G_blocks!(G, dl, du, block_B, block_A, block_d, block_Aw, block_dw, s0, E, F, K, N)
 
     for i in 1:N
         Jac1[:, :, i] = @view G[(1 + nc * (i - 1)):(nc * i), :]
@@ -756,19 +778,22 @@ function _build_block_matrices(
     # Define block matrices
     block_A   = _init_similar(A, ns * (N + 1), ns, T)
     block_B   = _init_similar(B, ns * N, nu, T)
-    block_Aw  = _init_similar(w, ns * N, T)
+    block_Aw  = _init_similar(w, ns * (N + 1), T)
     block_h   = _init_similar(A, nu * N, ns, T)
     block_h01 = _init_similar(A, ns, ns, T)
-    block_h02 = _init_similar(w, ns * N, T)
+    block_h02 = _init_similar(w, ns, T)
     h_const   = _init_similar(w, nu * N, T)
-    h0_const  = _init_similar(w, 1, T)
+    h0_const  = T(0)
     block_d   = _init_similar(A, nc * N, ns, T)
-    block_dw  = _init_similar(A, nc * N, ns, T)
+    block_dw  = _init_similar(w, nc * N, T)
     block_KA  = _init_similar(A, nu * N, ns, T)
+    block_KAw = _init_similar(w, nu * N, T)
 
     A_k = copy(A)
     BK  = _init_similar(A, ns, ns, T)
     KA  = _init_similar(A, nu, ns, T)
+    KAw = _init_similar(w, nu, T)
+    Aw  = _init_similar(A, ns, T)
 
     AB_klast = _init_similar(A, size(B, 1), size(B, 2), T)
     AB_k     = _init_similar(A, size(B, 1), size(B, 2), T)
@@ -815,6 +840,20 @@ function _build_block_matrices(
 
     block_A[(ns * N + 1):ns * (N + 1), :] = A_knext
 
+    for i in 1:(N + 1)
+        A_view = @view block_A[(1 + (i - 1) * ns):(i * ns), :]
+        LinearAlgebra.mul!(Aw, A_view, w)
+        for j in i:N
+            block_Aw[(1 + (j - 1) * ns):(j * ns)] .+= Aw
+        end
+    end
+
+    for i in 1:N
+        Aw_view = @view block_Aw[(1 + (i - 1) * ns):(i * ns)]
+        LinearAlgebra.mul!(KAw, K, Aw_view)
+        block_KAw[(1 + (i - 1) * nu):(i * nu)] .= KAw
+    end
+
     DenseLQDynamicBlocks{T, V, M}(
         block_A,
         block_B,
@@ -826,12 +865,13 @@ function _build_block_matrices(
         h0_const,
         block_d,
         block_dw,
-        block_KA
+        block_KA,
+        block_KAw
     )
 end
 
 function _build_H_blocks(
-    Q, R, block_A::M, block_B::M,
+    Q, R, block_A::M, block_B::M, Aw,
     S, Qf, K, s0, N
 ) where {T, M <: AbstractMatrix{T}}
     ns = size(Q, 1)
@@ -843,11 +883,15 @@ function _build_H_blocks(
 
     H = _init_similar(block_A, nu * N, nu * N, T)
 
-    # block_h0 and block_h are stored in DenseLQDynamicBlocks to provide quick updates when redefining s0
-    # block_h0 = A^T((Q + KTRK + 2 * SK))A where Q, K, R, S, and A are block matrices
+    # block_h01, block_h02, and block_h are stored in DenseLQDynamicBlocks to provide quick updates when redefining s0
+    # block_h01 = A^T((Q + KTRK + 2 * SK))A where Q, K, R, S, and A are block matrices
+    # block_h02 = A^T((Q + KTRK + 2 * SK))block_matrix_A w
     # block_h  = (QB + SKB + K^T R K B + K^T S^T B)^T A + (S + K^T R)^T A
-    block_h0     = _init_similar(Q, ns, ns, T)
-    block_h      = _init_similar(block_A, nu * N, ns, T)
+    block_h01   = _init_similar(Q, ns, ns, T)
+    block_h02   = _init_similar(s0, ns, T)
+    block_h     = _init_similar(block_A, nu * N, ns, T)
+    h_constant  = _init_similar(s0, nu * N, T)
+    h0_constant = T(0)
 
     # quad term refers to the summation of Q, K^T RK, SK, and K^T S^T that is left and right multiplied by B in the Hessian
     quad_term    = _init_similar(Q, ns, ns, T)
@@ -871,10 +915,18 @@ function _build_H_blocks(
 
     BTQA         = _init_similar(Q, nu, ns, T)
     RK_STA       = _init_similar(Q, nu, ns, T)
+    BTQAw        = _init_similar(s0, nu, T)
+    RK_STAw      = _init_similar(s0, nu, T)
+
     QA           = _init_similar(Q, ns, ns, T)
     KTRKA        = _init_similar(Q, ns, ns, T)
     SKA          = _init_similar(Q, ns, ns, T)
-    AQAs0         = _init_similar(s0, ns, T)
+
+    QAw          = _init_similar(s0, ns, T)
+    KTRKAw       = _init_similar(s0, ns, T)
+    SKAw         = _init_similar(s0, ns, T)
+
+    AQAs0        = _init_similar(s0, ns, T)
 
     LinearAlgebra.mul!(SK, S, K)
     LinearAlgebra.mul!(RK, R, K)
@@ -904,7 +956,6 @@ function _build_H_blocks(
             right_block = block_B[(1 + (j - 1 + i - 1) * ns):((j + i - 1)* ns), :]
             LinearAlgebra.mul!(BQB, quad_term_AB', right_block)
             LinearAlgebra.mul!(BQfB, QfAB', right_block)
-
 
             for k in 1:(N - j - i + 2)
                 row_range = (1 + nu * (k + (j - 1) - 1)):(nu * (k + (j - 1)))
@@ -941,34 +992,70 @@ function _build_H_blocks(
         LinearAlgebra.mul!(BTQA, QB_block_vec', block_A)
         LinearAlgebra.mul!(RK_STA, RK_ST, block_A[(ns * (i - 1) + 1):(ns * i), :])
 
+        LinearAlgebra.mul!(BTQAw, QB_block_vec', Aw)
+        LinearAlgebra.mul!(RK_STAw, RK_ST, Aw[(1 + ns * (i - 1)):(ns * i)])
+
         h_view = @view block_h[(1 + nu * (i - 1)):(nu * i), :]
 
         LinearAlgebra.axpy!(1, BTQA, h_view)
         LinearAlgebra.axpy!(1, RK_STA, h_view)
 
-        A_view = @view block_A[(1 + ns * (i - 1)):(ns * i), :]
+        h_constant_view = @view h_constant[(1 + nu * (i - 1)):(nu * i)]
+
+        LinearAlgebra.axpy!(1, BTQAw, h_constant_view)
+        LinearAlgebra.axpy!(1, RK_STAw, h_constant_view)
+
+        A_view  = @view block_A[(1 + ns * (i - 1)):(ns * i), :]
+        Aw_view = @view Aw[(1 + ns * (i - 1)):(ns * i)]
+
         LinearAlgebra.mul!(QA, Q, A_view)
         LinearAlgebra.mul!(KTRKA, KTRK, A_view)
         LinearAlgebra.mul!(SKA, SK, A_view)
 
-        LinearAlgebra.mul!(block_h0, A_view', QA, 1, 1)
-        LinearAlgebra.mul!(block_h0, A_view', KTRKA, 1, 1)
-        LinearAlgebra.mul!(block_h0, A_view', SKA, 2, 1)
+        LinearAlgebra.mul!(QAw, Q, Aw_view)
+        LinearAlgebra.mul!(KTRKAw, Q, Aw_view)
+        LinearAlgebra.mul!(SKAw, SK, Aw_view)
+
+        LinearAlgebra.mul!(block_h01, A_view', QA, 1, 1)
+        LinearAlgebra.mul!(block_h01, A_view', KTRKA, 1, 1)
+        LinearAlgebra.mul!(block_h01, A_view', SKA, 2, 1)
+
+        LinearAlgebra.mul!(block_h02, A_view', QAw, 1, 1)
+        LinearAlgebra.mul!(block_h02, A_view', KTRKAw, 1, 1)
+        LinearAlgebra.mul!(block_h02, A_view', SKAw, 1, 1)
+
+        h0_constant += LinearAlgebra.dot(Aw_view, QAw)
+        h0_constant += LinearAlgebra.dot(Aw_view, KTRKAw)
+        h0_constant += LinearAlgebra.dot(Aw_view, SKAw)
+        #LinearAlgebra.mul!(h0_constant, Aw_view', QAw, 1, 1)
+        #LinearAlgebra.mul!(h0_constant, Aw_view', KTRKAw, 1, 1)
+        #LinearAlgebra.mul!(h0_constant, Aw_view', SKAw, 1, 1)
     end
 
-    A_view = @view block_A[(1 + ns * N):(ns * (N + 1)), :]
+    A_view  = @view block_A[(1 + ns * N):(ns * (N + 1)), :]
+    Aw_view = @view Aw[(1 + ns * N):(ns * (N + 1))]
     LinearAlgebra.mul!(QA, Qf, A_view)
-    LinearAlgebra.mul!(block_h0, A_view', QA, 1, 1)
+    LinearAlgebra.mul!(block_h01, A_view', QA, 1, 1)
+
+    LinearAlgebra.mul!(QAw, Qf, Aw_view)
+    LinearAlgebra.mul!(block_h02, A_view', QAw, 1, 1)
+    h0_constant += LinearAlgebra.dot(Aw_view, QAw)
+    #LinearAlgebra.mul!(h0_constant, Aw_view', QAw, 1, 1)
 
     LinearAlgebra.mul!(h, block_h, s0)
-    LinearAlgebra.mul!(AQAs0, block_h0, s0)
+    LinearAlgebra.mul!(AQAs0, block_h01, s0)
     h0 = LinearAlgebra.dot(AQAs0, s0)
 
-    return (H = H, c = h, c0 = h0 / T(2), block_h = block_h, block_h0 = block_h0)
+    h0 += h0_constant
+    h0 += LinearAlgebra.dot(block_h02, s0) * T(2)
+
+    h += h_constant
+
+    return (H = H, c = h, c0 = h0 / T(2), block_h = block_h, block_h01 = block_h01, block_h02 = block_h02, h_constant = h_constant, h0_constant = h0_constant / T(2))
 end
 
 function _set_G_blocks!(
-    G, dl, du, block_B::M, block_A::M, block_d::M,
+    G, dl, du, block_B::M, block_A::M, block_d::M, block_Aw, block_dw,
     s0, E, F, K::MK, N
 ) where {T, M <: AbstractMatrix{T}, MK <: Nothing}
     ns = size(E, 2)
@@ -979,6 +1066,7 @@ function _set_G_blocks!(
 
     EB   = _init_similar(block_B, nc, nu, T)
     EA   = _init_similar(block_B, nc, ns, T)
+    d    = _init_similar(block_dw, nc, T)
 
     for i in 1:N
         if i != N
@@ -988,17 +1076,22 @@ function _set_G_blocks!(
             LinearAlgebra.mul!(EB, E, B_sub_block)
             G[(1 + nc * i):(nc * (i + 1)), :] = EB
         end
-        A_view = @view block_A[(1 + ns * (i - 1)):(ns * i), :]
+        A_view  = @view block_A[(1 + ns * (i - 1)):(ns * i), :]
+        Aw_view = @view block_Aw[(1 + ns * (i - 1)):(ns * i)]
         LinearAlgebra.mul!(EA, E, A_view)
+        LinearAlgebra.mul!(d, E, Aw_view)
 
         block_d[(1 + nc * (i - 1)):(nc * i), :] .= EA
+        block_dw[(1 + nc * (i - 1)):(nc *i)]    .= d
     end
     LinearAlgebra.mul!(dl, block_d, s0, -1, 1)
     LinearAlgebra.mul!(du, block_d, s0, -1, 1)
+    LinearAlgebra.axpy!(-1, block_dw, dl)
+    LinearAlgebra.axpy!(-1, block_dw, du)
 end
 
 function _set_G_blocks!(
-    G, dl, du, block_B, block_A, block_d,
+    G, dl, du, block_B, block_A, block_d, block_Aw, block_dw,
     s0, E, F, K::MK, N
 ) where {T, MK <: AbstractMatrix{T}}
     ns = size(E, 2)
@@ -1011,6 +1104,7 @@ function _set_G_blocks!(
     E_FKA = _init_similar(E, nc, ns, T)
     FK    = _init_similar(E, nc, ns, T)
     EB    = _init_similar(E, nc, nu, T)
+    d     = _init_similar(s0, nc, T)
 
     LinearAlgebra.copyto!(E_FK, E)
     LinearAlgebra.mul!(FK, F, K)
@@ -1024,13 +1118,18 @@ function _set_G_blocks!(
             LinearAlgebra.mul!(EB, E_FK, B_sub_block)
             G[(1 + nc * i):(nc * (i + 1)), :] = EB
         end
-        A_view = @view block_A[(1 + ns * (i - 1)):(ns * i), :]
+        A_view  = @view block_A[(1 + ns * (i - 1)):(ns * i), :]
+        Aw_view = @view block_Aw[(1 + ns *(i - 1)):(ns * i)]
         LinearAlgebra.mul!(E_FKA, E_FK, A_view)
+        LinearAlgebra.mul!(d, E_FK, Aw_view)
 
         block_d[(1 + nc * (i - 1)):(nc * i), :] .= E_FKA
+        block_dw[(1 + nc * (i - 1)):(nc * i)]   .= d
     end
     LinearAlgebra.mul!(dl, block_d, s0, -1, 1)
     LinearAlgebra.mul!(du, block_d, s0, -1, 1)
+    LinearAlgebra.axpy!(-1, block_dw, dl)
+    LinearAlgebra.axpy!(-1, block_dw, du)
 end
 
 function _set_J1_dense!(J1, G, N)

--- a/src/LinearQuadratic/sparse.jl
+++ b/src/LinearQuadratic/sparse.jl
@@ -6,7 +6,7 @@ A constructor for building a `SparseLQDynamicModel <: QuadraticModels.AbstractQu
 Input data is for the problem of the form
 ```math
 minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
-subject to  s_{i+1} = A s_i + B u_i  for i=0, 1, ..., N-1
+subject to  s_{i+1} = A s_i + B u_i + w for i=0, 1, ..., N-1
             u_i = Kx_i + v_i  \\forall i = 0, 1, ..., N - 1
             gl \\le E s_i + F u_i \\le gu for i = 0, 1, ..., N-1
             sl \\le s \\le su
@@ -54,7 +54,7 @@ function SparseLQDynamicModel(
 
     dnlp = LQDynamicData(
         s0, A, B, Q, R, N;
-        Qf = Qf, S = S, E = E, F = F, K = K, w,
+        Qf = Qf, S = S, E = E, F = F, K = K, w = w,
         sl = sl, su = su, ul = ul, uu = uu, gl = gl, gu = gu
     )
 
@@ -131,8 +131,8 @@ function _build_sparse_lq_dynamic_model(
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
 
-        lcon[(1 + (i - 1) * ns):(i * ns)] = w
-        ucon[(1 + (i - 1) * ns):(i * ns)] = w
+        lcon[(1 + (i - 1) * ns):(i * ns)] = -w
+        ucon[(1 + (i - 1) * ns):(i * ns)] = -w
 
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu
@@ -282,8 +282,8 @@ function _build_sparse_lq_dynamic_model(
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
 
-        lcon[(1 + (i - 1) * ns):(i * ns)] = w
-        ucon[(1 + (i - 1) * ns):(i * ns)] = w
+        lcon[(1 + (i - 1) * ns):(i * ns)] = -w
+        ucon[(1 + (i - 1) * ns):(i * ns)] = -w
 
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu
@@ -395,8 +395,8 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
 
-        lcon[(1 + (i - 1) * ns):(i * ns)] = w
-        ucon[(1 + (i - 1) * ns):(i * ns)] = w
+        lcon[(1 + (i - 1) * ns):(i * ns)] = -w
+        ucon[(1 + (i - 1) * ns):(i * ns)] = -w
 
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu
@@ -562,8 +562,8 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
 
-        lcon[(1 + (i - 1) * ns):(i * ns)] = w
-        ucon[(1 + (i - 1) * ns):(i * ns)] = w
+        lcon[(1 + (i - 1) * ns):(i * ns)] = -w
+        ucon[(1 + (i - 1) * ns):(i * ns)] = -w
 
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu

--- a/src/LinearQuadratic/sparse.jl
+++ b/src/LinearQuadratic/sparse.jl
@@ -43,6 +43,7 @@ function SparseLQDynamicModel(
     E::M  = _init_similar(Q, 0, length(s0), T),
     F::M  = _init_similar(Q, 0, size(R, 1), T),
     K::MK = nothing,
+    w::V  = _init_similar(s0, length(s0), T),
     sl::V = (similar(s0) .= -Inf),
     su::V = (similar(s0) .=  Inf),
     ul::V = (similar(s0, size(R, 1)) .= -Inf),
@@ -53,7 +54,7 @@ function SparseLQDynamicModel(
 
     dnlp = LQDynamicData(
         s0, A, B, Q, R, N;
-        Qf = Qf, S = S, E = E, F = F, K = K,
+        Qf = Qf, S = S, E = E, F = F, K = K, w,
         sl = sl, su = su, ul = ul, uu = uu, gl = gl, gu = gu
     )
 
@@ -78,6 +79,7 @@ function _build_sparse_lq_dynamic_model(
     E  = dnlp.E
     F  = dnlp.F
     K  = dnlp.K
+    w  = dnlp.w
 
     sl = dnlp.sl
     su = dnlp.su
@@ -128,6 +130,9 @@ function _build_sparse_lq_dynamic_model(
     for i in 1:N
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
+
+        lcon[(1 + (i - 1) * ns):(i * ns)] = w
+        ucon[(1 + (i - 1) * ns):(i * ns)] = w
 
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu
@@ -181,6 +186,7 @@ function _build_sparse_lq_dynamic_model(
     E  = dnlp.E
     F  = dnlp.F
     K  = dnlp.K
+    w  = dnlp.w
 
     sl = dnlp.sl
     su = dnlp.su
@@ -276,6 +282,9 @@ function _build_sparse_lq_dynamic_model(
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
 
+        lcon[(1 + (i - 1) * ns):(i * ns)] = w
+        ucon[(1 + (i - 1) * ns):(i * ns)] = w
+
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu
     end
@@ -328,6 +337,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     E  = dnlp.E
     F  = dnlp.F
     K  = dnlp.K
+    w  = dnlp.w
 
     sl = dnlp.sl
     su = dnlp.su
@@ -385,6 +395,9 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
 
+        lcon[(1 + (i - 1) * ns):(i * ns)] = w
+        ucon[(1 + (i - 1) * ns):(i * ns)] = w
+
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu
     end
@@ -436,6 +449,7 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     E  = dnlp.E
     F  = dnlp.F
     K  = dnlp.K
+    w  = dnlp.w
 
     sl = dnlp.sl
     su = dnlp.su
@@ -547,6 +561,9 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     for i in 1:N
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
+
+        lcon[(1 + (i - 1) * ns):(i * ns)] = w
+        ucon[(1 + (i - 1) * ns):(i * ns)] = w
 
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu

--- a/src/LinearQuadratic/sparse.jl
+++ b/src/LinearQuadratic/sparse.jl
@@ -6,7 +6,7 @@ A constructor for building a `SparseLQDynamicModel <: QuadraticModels.AbstractQu
 Input data is for the problem of the form
 ```math
 minimize    \\frac{1}{2} \\sum_{i = 0}^{N-1}(s_i^T Q s_i + 2 u_i^T S^T x_i + u_i^T R u_i) + \\frac{1}{2} s_N^T Qf s_N
-subject to  s_{i+1} = A s_i + B u_i + w for i=0, 1, ..., N-1
+subject to  s_{i+1} = A s_i + B u_i + w_i for i=0, 1, ..., N-1
             u_i = Kx_i + v_i  \\forall i = 0, 1, ..., N - 1
             gl \\le E s_i + F u_i \\le gu for i = 0, 1, ..., N-1
             sl \\le s \\le su
@@ -43,7 +43,7 @@ function SparseLQDynamicModel(
     E::M  = _init_similar(Q, 0, length(s0), T),
     F::M  = _init_similar(Q, 0, size(R, 1), T),
     K::MK = nothing,
-    w::V  = _init_similar(s0, length(s0), T),
+    w::V  = _init_similar(s0, length(s0) * N, T),
     sl::V = (similar(s0) .= -Inf),
     su::V = (similar(s0) .=  Inf),
     ul::V = (similar(s0, size(R, 1)) .= -Inf),
@@ -127,12 +127,12 @@ function _build_sparse_lq_dynamic_model(
     nnzj = length(J.rowval)
     nnzh = length(H.rowval)
 
+    lcon[1:(ns * N)] .= -w
+    ucon[1:(ns * N)] .= -w
+
     for i in 1:N
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
-
-        lcon[(1 + (i - 1) * ns):(i * ns)] = -w
-        ucon[(1 + (i - 1) * ns):(i * ns)] = -w
 
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu
@@ -274,6 +274,9 @@ function _build_sparse_lq_dynamic_model(
     lcon  = _init_similar(s0, ns * N + N * length(gl) + length(lcon3))
     ucon  = _init_similar(s0, ns * N + N * length(gl) + length(lcon3))
 
+    lcon[1:(ns * N)] .= -w
+    ucon[1:(ns * N)] .= -w
+
     ncon  = size(J, 1)
     nnzj = length(J.rowval)
     nnzh = length(H.rowval)
@@ -281,9 +284,6 @@ function _build_sparse_lq_dynamic_model(
     for i in 1:N
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
-
-        lcon[(1 + (i - 1) * ns):(i * ns)] = -w
-        ucon[(1 + (i - 1) * ns):(i * ns)] = -w
 
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu
@@ -391,12 +391,12 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     nnzj = length(J.rowval)
     nnzh = length(H.rowval)
 
+    lcon[1:(ns * N)] .= -w
+    ucon[1:(ns * N)] .= -w
+
     for i in 1:N
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
-
-        lcon[(1 + (i - 1) * ns):(i * ns)] = -w
-        ucon[(1 + (i - 1) * ns):(i * ns)] = -w
 
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu
@@ -558,12 +558,12 @@ function _build_sparse_lq_dynamic_model(dnlp::LQDynamicData{T, V, M, MK}) where 
     nnzj = length(J.rowval)
     nnzh = length(H.rowval)
 
+    lcon[1:(ns * N)] .= -w
+    ucon[1:(ns * N)] .= -w
+
     for i in 1:N
         lvar[(i * ns + 1):((i + 1) * ns)] = sl
         uvar[(i * ns + 1):((i + 1) * ns)] = su
-
-        lcon[(1 + (i - 1) * ns):(i * ns)] = -w
-        ucon[(1 + (i - 1) * ns):(i * ns)] = -w
 
         lcon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gl
         ucon[(ns * N + 1 + (i -1) * nc):(ns * N + i * nc)] = gu

--- a/src/LinearQuadratic/tools.jl
+++ b/src/LinearQuadratic/tools.jl
@@ -51,8 +51,9 @@ function get_u(
     nu   = dnlp.nu
     K    = dnlp.K
 
-    block_A = lqdm.blocks.A
-    block_B = lqdm.blocks.B
+    block_A  = lqdm.blocks.A
+    block_B  = lqdm.blocks.B
+    block_Aw = lqdm.blocks.Aw
 
     v = solver_status.solution
 
@@ -74,6 +75,7 @@ function get_u(
 
     LinearAlgebra.mul!(As0, block_A, dnlp.s0)
     LinearAlgebra.axpy!(1, As0, s)
+    LinearAlgebra.axpy!(1, block_Aw, s)
 
     Ks = _init_similar(dnlp.s0, size(K, 1), T)
     u = copy(v)
@@ -138,8 +140,9 @@ function get_s(
     ns   = dnlp.ns
     nu   = dnlp.nu
 
-    block_A = lqdm.blocks.A
-    block_B = lqdm.blocks.B
+    block_A  = lqdm.blocks.A
+    block_B  = lqdm.blocks.B
+    block_Aw = lqdm.blocks.Aw
 
     v = solver_status.solution
 
@@ -161,6 +164,7 @@ function get_s(
 
     LinearAlgebra.mul!(As0, block_A, dnlp.s0)
     LinearAlgebra.axpy!(1, As0, s)
+    LinearAlgebra.axpy!(1, block_Aw, s)
 
     return s
 end
@@ -817,8 +821,8 @@ function reset_s0!(
 
     for i in 1:N
         # Reset bounds on constraints from state variable bounds
-        lcon[(1 + nc * N + nsc * (i - 1)):(nc * N + nsc * i)] .= sl .- As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s] .- block_Aw[(1 + (i - 1) * ns):(i * ns)][bool_vec_s]
-        ucon[(1 + nc * N + nsc * (i - 1)):(nc * N + nsc * i)] .= su .- As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s] .- block_Aw[(1 + (i - 1) * ns):(i * ns)][bool_vec_s]
+        lcon[(1 + nc * N + nsc * (i - 1)):(nc * N + nsc * i)] .= sl .- As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s] .- block_Aw[(1 + ns * i):((i + 1) * ns)][bool_vec_s]
+        ucon[(1 + nc * N + nsc * (i - 1)):(nc * N + nsc * i)] .= su .- As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s] .- block_Aw[(1 + ns * i):((i + 1) * ns)][bool_vec_s]
     end
 end
 
@@ -908,8 +912,8 @@ function reset_s0!(
 
     for i in 1:N
         # Reset bounds on constraints from state variable bounds
-        lcon[(1 + nc * N + nsc * (i - 1)):(nc * N + nsc * i)] .= sl .- As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s] .- block_Aw[(1 + (i - 1) * ns):(i * ns)][bool_vec_s]
-        ucon[(1 + nc * N + nsc * (i - 1)):(nc * N + nsc * i)] .= su .- As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s] .- block_Aw[(1 + (i - 1) * ns):(i * ns)][bool_vec_s]
+        lcon[(1 + nc * N + nsc * (i - 1)):(nc * N + nsc * i)] .= sl .- As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s] .- block_Aw[(1 + i * ns):((i + 1) * ns)][bool_vec_s]
+        ucon[(1 + nc * N + nsc * (i - 1)):(nc * N + nsc * i)] .= su .- As0[(1 + ns * i):(ns * (i + 1))][bool_vec_s] .- block_Aw[(1 + i * ns):((i + 1) * ns)][bool_vec_s]
 
         # Reset bounds on constraints from input variable bounds
         lcon[(1 + (nc + nsc) * N + nuc * (i - 1)):((nc + nsc) * N + nuc * i)] .= ul .- KAs0[(1 + nu * (i - 1)):(nu * i)][bool_vec_u] .- block_KAw[(1 + nu * (i - 1)):(nu * i)][bool_vec_u]

--- a/src/LinearQuadratic/tools.jl
+++ b/src/LinearQuadratic/tools.jl
@@ -262,7 +262,7 @@ function NLPModels.hess_coord!(
     x::AbstractVector{T},
     vals::AbstractVector{T};
     obj_weight::Real = one(eltype(x)),
-) where {T, V, M1 <: SparseMatrixCSC, M2 <: SparseMatrixCSC, M3 <: Matrix}
+) where {T, V, M1 <: SparseMatrixCSC, M2 <: SparseMatrixCSC, M3 <: AbstractMatrix}
     NLPModels.increment!(qp, :neval_hess)
     fill_coord!(qp.data.H, vals, obj_weight)
     return vals

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,7 +40,7 @@ gu = fill(15.0, 3)
 
 S = rand(ns, nu)
 
-w = rand(0.0:.0001:.25, ns)
+w = rand(0.0:.0001:.25, ns * N)
 
 K = rand(nu, ns)
 
@@ -262,7 +262,7 @@ sl = s0 .- 1
 su = s0 .+ 1
 ul = randn(Float32,2)
 uu = ul .+ 2
-w = Float32.(rand(0.0:.0001:.25, ns))
+w = Float32.(rand(0.0:.0001:.25, ns * 10))
 
 s0 = Test.GenericArray(s0)
 A  = Test.GenericArray(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,3 @@
-using Revise
 using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra, SparseArrays, CUDA
 include("sparse_lq_test.jl")
 include("functions.jl")
@@ -263,7 +262,7 @@ sl = s0 .- 1
 su = s0 .+ 1
 ul = randn(Float32,2)
 uu = ul .+ 2
-w = Float32(rand(0.0:.0001:.25, ns))
+w = Float32.(rand(0.0:.0001:.25, ns))
 
 s0 = Test.GenericArray(s0)
 A  = Test.GenericArray(A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Revise
 using Test, DynamicNLPModels, MadNLP, Random, JuMP, LinearAlgebra, SparseArrays, CUDA
 include("sparse_lq_test.jl")
 include("functions.jl")
@@ -40,82 +41,84 @@ gu = fill(15.0, 3)
 
 S = rand(ns, nu)
 
+w = rand(0.0:.0001:.25, ns)
+
 K = rand(nu, ns)
 
 # Test with no bounds
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
 # Test with lower bounds
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N;  sl = sl, ul=ul)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N;  sl = sl, ul = ul, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
 # Test with upper bounds
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, su = su, uu = uu)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; su = su, uu = uu)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, su = su, uu = uu, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; su = su, uu = uu, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; su = su, uu = uu)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; su = su, uu = uu)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; su = su, uu = uu, w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; su = su, uu = uu, w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
 # Test with upper and lower bounds
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl=sl, ul=ul, su = su, uu = uu)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl=sl, ul=ul, su = su, uu = uu)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl=sl, ul=ul, su = su, uu = uu, w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl=sl, ul=ul, su = su, uu = uu, w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
 # Test with Qf matrix
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, Qf=Qf)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, Qf = Qf, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf, w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, Qf = Qf, w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
 # Test with E and F matrix bounds
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
 # Test edge case where one state is unbounded, other(s) is bounded
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu, w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl_with_inf, ul = ul, su = su_with_inf, uu = uu, E = E, F = F, gl = gl, gu = gu, w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
@@ -123,35 +126,35 @@ runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_da
 
 
 # Test S matrix case
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S, w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, S = S, w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
 # Test K matrix case without S
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
 # Test K matrix case with S
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S, w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S, w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
@@ -182,30 +185,30 @@ S = rand(ns, nu)
 
 K = rand(nu, ns)
 
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S, w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; sl = sl, ul = ul_with_inf, su = su, uu = uu_with_inf, E = E, F = F, gl = gl, gu = gu, K = K, S = S, w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
 # Test K with no bounds
-model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, E = E, F = F, gl = gl, gu = gu, K = K)
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K)
+model     = build_QP_JuMP_model(Q,R,A,B, N;s0=s0, E = E, F = F, gl = gl, gu = gu, K = K, w = w)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
-lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K)
-lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K)
+lq_sparse_from_data = SparseLQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K, w = w)
+lq_dense_from_data  = DenseLQDynamicModel(s0, A, B, Q, R, N; E = E, F = F, gl = gl, gu = gu, K = K, w = w)
 
 runtests(model, dnlp, lq_sparse, lq_dense, lq_sparse_from_data, lq_dense_from_data, N, ns, nu)
 
 # Test get_* and set_* functions
 
-dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S)
+dnlp      = LQDynamicData(copy(s0), A, B, Q, R, N; sl = sl, ul = ul, su = su, uu = uu, E = E, F = F, gl = gl, gu = gu, K = K, S = S, w = w)
 lq_sparse = SparseLQDynamicModel(dnlp)
 lq_dense  = DenseLQDynamicModel(dnlp)
 
@@ -260,6 +263,7 @@ sl = s0 .- 1
 su = s0 .+ 1
 ul = randn(Float32,2)
 uu = ul .+ 2
+w = Float32(rand(0.0:.0001:.25, ns))
 
 s0 = Test.GenericArray(s0)
 A  = Test.GenericArray(A)
@@ -276,14 +280,15 @@ sl = Test.GenericArray(sl)
 su = Test.GenericArray(su)
 ul = Test.GenericArray(ul)
 uu = Test.GenericArray(uu)
+w  = Test.GenericArray(w)
 
-@test (DenseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa
+@test (DenseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su, w = w) isa
     DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, Nothing})
-@test (DenseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa
+@test (DenseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su, w = w) isa
 DenseLQDynamicModel{Float32, GenericArray{Float32, 1}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}, GenericArray{Float32, 2}})
-@test (SparseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa
+@test (SparseLQDynamicModel(s0, A, B, Q, R, 10; S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su, w = w) isa
     SparseLQDynamicModel{Float32, GenericArray{Float32, 1}, SparseMatrixCSC{Float32, Int64}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}, Nothing})
-@test (SparseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su) isa
+@test (SparseLQDynamicModel(s0, A, B, Q, R, 10; K = K, S = S, E = E, F = F, gl = gl, gu = gu, ul = ul, uu = uu, sl = sl, su = su, w = w) isa
     SparseLQDynamicModel{Float32, GenericArray{Float32, 1}, SparseMatrixCSC{Float32, Int64}, SparseMatrixCSC{Float32, Int64}, GenericArray{Float32, 2}, GenericArray{Float32, 2}})
 
 # Test LQJacobianOperator APIs

--- a/test/sparse_lq_test.jl
+++ b/test/sparse_lq_test.jl
@@ -1,7 +1,7 @@
 """
     build_QP_JuMP_model(Q,R,A,B,N;...) -> JuMP.Model(...)
-Return a `JuMP.jl` Model for the quadratic problem 
-    
+Return a `JuMP.jl` Model for the quadratic problem
+
 min 1/2 ( sum_{i=1}^{N-1} s_i^T Q s + sum_{i=1}^{N-1} u^T R u + s_N^T Qf s_n  )
 s.t. s_{i+1} = As_i + Bs_i for i = 1,..., N-1
 Optional Arguments
@@ -15,8 +15,8 @@ Optional Arguments
 """
 function build_QP_JuMP_model(
         Q,R,A,B, N;
-        s0 = [],
-        sl = [], 
+        s0 = zeros(size(Q, 1)),
+        sl = [],
         su = [],
         ul = [],
         uu = [],
@@ -26,7 +26,8 @@ function build_QP_JuMP_model(
         gl = [],
         gu = [],
         S  = zeros(size(Q, 1), size(R, 1)),
-        K  = zeros(size(R, 1), size(Q, 1))
+        K  = zeros(size(R, 1), size(Q, 1)),
+        w  = zeros(size(Q, 1))
         )
 
     ns = size(Q,1) # Number of states
@@ -41,11 +42,11 @@ function build_QP_JuMP_model(
     model = Model(MadNLP.Optimizer) # define model
 
 
-    @variable(model, s[NS, 0:N])     # define states 
+    @variable(model, s[NS, 0:N])     # define states
     @variable(model, u[NU, 0:(N-1)]) # define inputs
 
     if !iszero(K)
-        @variable(model, v[NU, 0:(N-1)]) 
+        @variable(model, v[NU, 0:(N-1)])
     end
 
 
@@ -93,11 +94,13 @@ function build_QP_JuMP_model(
             JuMP.fix(s[i,0], s0[i])
         end
     end
-    
+
 
     # Give constraints from A, B, matrices
-    @constraint(model, [t in 0:(N - 1), s1 in NS], s[s1, t + 1] == sum(A[s1, s2] * s[s2, t] for s2 in NS) + sum(B[s1, u1] * u[u1, t] for u1 in NU) )
-    
+    for s1 in NS
+        @constraint(model, [t in 0:(N - 1)], s[s1, t + 1] == sum(A[s1, s2] * s[s2, t] for s2 in NS) + sum(B[s1, u1] * u[u1, t] for u1 in NU) + w[s1])
+    end
+
     # Constraints for Kx + v = u
     if !iszero(K)
         for u1 in NU
@@ -114,8 +117,8 @@ function build_QP_JuMP_model(
     end
 
     # Give objective function as xT Q x + uT R u where x is summed over T and u is summed over T-1
-    @objective(model,Min,  sum( 1/2 * Q[s1, s2]*s[s1,t]*s[s2,t] for s1 in NS, s2 in NS, t in 0:(N-1)) + 
-            sum( 1/2 * R[u1,u2] * u[u1, t] * u[u2,t] for t in 0:(N-1) , u1 in NU, u2 in NU) + 
+    @objective(model,Min,  sum( 1/2 * Q[s1, s2]*s[s1,t]*s[s2,t] for s1 in NS, s2 in NS, t in 0:(N-1)) +
+            sum( 1/2 * R[u1,u2] * u[u1, t] * u[u2,t] for t in 0:(N-1) , u1 in NU, u2 in NU) +
             sum( 1/2 * Qf[s1,s2] * s[s1,N] * s[s2, N]  for s1 in NS, s2 in NS) +
             sum( S[s1, u1] * s[s1, t] * u[u1, t] for s1 in NS, u1 in NU, t in 0:(N-1))
             )

--- a/test/sparse_lq_test.jl
+++ b/test/sparse_lq_test.jl
@@ -98,7 +98,9 @@ function build_QP_JuMP_model(
 
     # Give constraints from A, B, matrices
     for s1 in NS
-        @constraint(model, [t in 0:(N - 1)], s[s1, t + 1] == sum(A[s1, s2] * s[s2, t] for s2 in NS) + sum(B[s1, u1] * u[u1, t] for u1 in NU) + w[s1])
+        for t in 0:(N - 1)
+            @constraint(model, s[s1, t + 1] == sum(A[s1, s2] * s[s2, t] for s2 in NS) + sum(B[s1, u1] * u[u1, t] for u1 in NU) + w[s1 + t * ns])
+        end
     end
 
     # Constraints for Kx + v = u


### PR DESCRIPTION
For $x_{t + 1} = Ax_t + bu_t + w$, The vector `w` changes the constraint bounds and the linear/constant terms of the objective function. I derived the equations for these and updated the `SparseLQDynamicModel` and `DenseLQDynamicModel` to operate with `w`. I added tests to check this, and I updated the JuMP model that we used for comparison. This also required updating the `DenseLQDynamicBlocks` significantly to store the needed data to reset `s0`. 

For reference, the equation used for deriving this is $\boldsymbol{x} = \boldsymbol{A} \hat{x} + \boldsymbol{B} \boldsymbol{v} + \tilde{\boldsymbol{A}}\boldsymbol{w}$. In this case, $\tilde{\boldsymbol{A}}$ is the same format as $\boldsymbol{B}$ but with the identity matrix in place of the $B$ matrix. 